### PR TITLE
Fixes to get it building on Mac OS X

### DIFF
--- a/src/MagnumPlugins/FreeTypeFont/CMakeLists.txt
+++ b/src/MagnumPlugins/FreeTypeFont/CMakeLists.txt
@@ -24,7 +24,10 @@
 #
 
 find_package(Magnum REQUIRED Text TextureTools)
+set(PREV_CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK})
+set(CMAKE_FIND_FRAMEWORK LAST)
 find_package(Freetype REQUIRED)
+set(CMAKE_FIND_FRAMEWORK ${PREV_CMAKE_FIND_FRAMEWORK})
 
 include_directories(${FREETYPE_INCLUDE_DIRS})
 

--- a/src/MagnumPlugins/FreeTypeFont/FreeTypeFont.cpp
+++ b/src/MagnumPlugins/FreeTypeFont/FreeTypeFont.cpp
@@ -153,8 +153,8 @@ void FreeTypeFont::doFillGlyphCache(GlyphCache& cache, const std::vector<char32_
 
         /* Copy rendered bitmap to texture image */
         const FT_Bitmap& bitmap = glyph->bitmap;
-        CORRADE_INTERNAL_ASSERT(std::abs(bitmap.width-charPositions[i].sizeX()) <= 2);
-        CORRADE_INTERNAL_ASSERT(std::abs(bitmap.rows-charPositions[i].sizeY()) <= 2);
+        CORRADE_INTERNAL_ASSERT(std::abs((int)(bitmap.width-charPositions[i].sizeX())) <= 2);
+        CORRADE_INTERNAL_ASSERT(std::abs((int)(bitmap.rows-charPositions[i].sizeY())) <= 2);
         for(Int yin = 0, yout = charPositions[i].bottom(), ymax = bitmap.rows; yin != ymax; ++yin, ++yout)
             for(Int xin = 0, xout = charPositions[i].left(), xmax = bitmap.width; xin != xmax; ++xin, ++xout)
                 pixmap[yout*cache.textureSize().x() + xout] = bitmap.buffer[(bitmap.rows-yin-1)*bitmap.width + xin];


### PR DESCRIPTION
For some reason, it was finding the Freetype in /Libraries/Framworks/Mono first, this was the only way I could fix it.

Also, I was getting:
.../magnum-plugins/src/MagnumPlugins/FreeTypeFont/FreeTypeFont.cpp:156:33: error: call to 'abs' is ambiguous

for those two lines
