### PR TITLE
FreeTypeFont: link to Freetype's dependencies if it was built static

### DIFF
--- a/modules/FindFreetype.cmake
+++ b/modules/FindFreetype.cmake
@@ -1,0 +1,165 @@
+#.rst:
+# FindFreetype
+# ------------
+#
+# Locate FreeType library
+#
+# This module defines
+#
+# ::
+#
+#   FREETYPE_LIBRARIES, the library to link against
+#   FREETYPE_FOUND, if false, do not try to link to FREETYPE
+#   FREETYPE_INCLUDE_DIRS, where to find headers.
+#   FREETYPE_VERSION_STRING, the version of freetype found (since CMake 2.8.8)
+#   This is the concatenation of the paths:
+#   FREETYPE_INCLUDE_DIR_ft2build
+#   FREETYPE_INCLUDE_DIR_freetype2
+#
+#
+#
+# $FREETYPE_DIR is an environment variable that would correspond to the
+# ./configure --prefix=$FREETYPE_DIR used in building FREETYPE.
+
+#=============================================================================
+# Copyright 2007-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+# Created by Eric Wing.
+# Modifications by Alexander Neundorf.
+# This file has been renamed to "FindFreetype.cmake" instead of the correct
+# "FindFreeType.cmake" in order to be compatible with the one from KDE4, Alex.
+
+# Ugh, FreeType seems to use some #include trickery which
+# makes this harder than it should be. It looks like they
+# put ft2build.h in a common/easier-to-find location which
+# then contains a #include to a more specific header in a
+# more specific location (#include <freetype/config/ftheader.h>).
+# Then from there, they need to set a bunch of #define's
+# so you can do something like:
+# #include FT_FREETYPE_H
+# Unfortunately, using CMake's mechanisms like include_directories()
+# wants explicit full paths and this trickery doesn't work too well.
+# I'm going to attempt to cut out the middleman and hope
+# everything still works.
+
+set(FREETYPE_FIND_ARGS
+  HINTS
+    ENV FREETYPE_DIR
+  PATHS
+    /usr/X11R6
+    /usr/local/X11R6
+    /usr/local/X11
+    /usr/freeware
+    ENV GTKMM_BASEPATH
+    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
+)
+
+find_path(
+  FREETYPE_INCLUDE_DIR_ft2build
+  ft2build.h
+  ${FREETYPE_FIND_ARGS}
+  PATH_SUFFIXES
+    include/freetype2
+    include
+    freetype2
+)
+
+find_path(
+  FREETYPE_INCLUDE_DIR_freetype2
+  NAMES
+    freetype/config/ftheader.h
+    config/ftheader.h
+  ${FREETYPE_FIND_ARGS}
+  PATH_SUFFIXES
+    include/freetype2
+    include
+    freetype2
+)
+
+if(NOT FREETYPE_LIBRARY)
+  find_library(FREETYPE_LIBRARY_RELEASE
+    NAMES
+      freetype
+      libfreetype
+      freetype219
+    ${FREETYPE_FIND_ARGS}
+    PATH_SUFFIXES
+      lib
+  )
+  find_library(FREETYPE_LIBRARY_DEBUG
+    NAMES
+      freetyped
+      libfreetyped
+      freetype219d
+    ${FREETYPE_FIND_ARGS}
+    PATH_SUFFIXES
+      lib
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
+  select_library_configurations(FREETYPE)
+endif()
+
+unset(FREETYPE_FIND_ARGS)
+
+# set the user variables
+if(FREETYPE_INCLUDE_DIR_ft2build AND FREETYPE_INCLUDE_DIR_freetype2)
+  set(FREETYPE_INCLUDE_DIRS "${FREETYPE_INCLUDE_DIR_ft2build};${FREETYPE_INCLUDE_DIR_freetype2}")
+  list(REMOVE_DUPLICATES FREETYPE_INCLUDE_DIRS)
+endif()
+set(FREETYPE_LIBRARIES "${FREETYPE_LIBRARY}")
+
+if(EXISTS "${FREETYPE_INCLUDE_DIR_freetype2}/freetype/freetype.h")
+  set(FREETYPE_H "${FREETYPE_INCLUDE_DIR_freetype2}/freetype/freetype.h")
+elseif(EXISTS "${FREETYPE_INCLUDE_DIR_freetype2}/freetype.h")
+  set(FREETYPE_H "${FREETYPE_INCLUDE_DIR_freetype2}/freetype.h")
+endif()
+
+if(FREETYPE_INCLUDE_DIR_freetype2 AND FREETYPE_H)
+  file(STRINGS "${FREETYPE_H}" freetype_version_str
+       REGEX "^#[\t ]*define[\t ]+FREETYPE_(MAJOR|MINOR|PATCH)[\t ]+[0-9]+$")
+
+  unset(FREETYPE_VERSION_STRING)
+  foreach(VPART MAJOR MINOR PATCH)
+    foreach(VLINE ${freetype_version_str})
+      if(VLINE MATCHES "^#[\t ]*define[\t ]+FREETYPE_${VPART}[\t ]+([0-9]+)$")
+        set(FREETYPE_VERSION_PART "${CMAKE_MATCH_1}")
+        if(FREETYPE_VERSION_STRING)
+          set(FREETYPE_VERSION_STRING "${FREETYPE_VERSION_STRING}.${FREETYPE_VERSION_PART}")
+        else()
+          set(FREETYPE_VERSION_STRING "${FREETYPE_VERSION_PART}")
+        endif()
+        unset(FREETYPE_VERSION_PART)
+      endif()
+    endforeach()
+  endforeach()
+endif()
+
+
+# handle the QUIETLY and REQUIRED arguments and set FREETYPE_FOUND to TRUE if
+# all listed variables are TRUE
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+find_package_handle_standard_args(
+  Freetype
+  REQUIRED_VARS
+    FREETYPE_LIBRARY
+    FREETYPE_INCLUDE_DIRS
+  VERSION_VAR
+    FREETYPE_VERSION_STRING
+)
+
+mark_as_advanced(
+  FREETYPE_INCLUDE_DIR_freetype2
+  FREETYPE_INCLUDE_DIR_ft2build
+)

--- a/modules/FindHarfBuzz.cmake
+++ b/modules/FindHarfBuzz.cmake
@@ -10,6 +10,7 @@
 # Additionally these variables are defined for internal usage:
 #
 #  HARFBUZZ_LIBRARY         - HarfBuzz library
+#  HARFBUZZ_LIBRARIES       - Same as HARFBUZZ_LIBRARY
 #  HARFBUZZ_INCLUDE_DIR     - Include dir
 #
 
@@ -61,3 +62,5 @@ if(NOT TARGET HarfBuzz::HarfBuzz)
         IMPORTED_LOCATION ${HARFBUZZ_LIBRARY}
         INTERFACE_INCLUDE_DIRECTORIES ${HARFBUZZ_INCLUDE_DIR})
 endif()
+
+set(HARFBUZZ_LIBRARIES ${HARFBUZZ_LIBRARY})

--- a/src/MagnumPlugins/FreeTypeFont/CMakeLists.txt
+++ b/src/MagnumPlugins/FreeTypeFont/CMakeLists.txt
@@ -73,7 +73,8 @@ target_include_directories(FreeTypeFont PUBLIC
 target_link_libraries(FreeTypeFont
     Magnum::Magnum
     Magnum::Text
-    ${FREETYPE_LIBRARIES})
+    ${FREETYPE_LIBRARIES}
+    ${FREETYPE_DEPENDENCY_LIBRARIES})
 
 install(FILES ${FreeTypeFont_HEADERS} DESTINATION ${MAGNUM_PLUGINS_INCLUDE_INSTALL_DIR}/FreeTypeFont)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/configure.h DESTINATION ${MAGNUM_PLUGINS_INCLUDE_INSTALL_DIR}/FreeTypeFont)
@@ -87,7 +88,8 @@ if(BUILD_TESTS)
     target_link_libraries(MagnumFreeTypeFontTestLib
         Magnum::Magnum
         Magnum::Text
-        ${FREETYPE_LIBRARIES})
+        ${FREETYPE_LIBRARIES}
+        ${FREETYPE_DEPENDENCY_LIBRARIES})
 endif()
 
 if(BUILD_GL_TESTS)


### PR DESCRIPTION
This allows users to build the FreeTypeFont plugin as a shared library even if they are using a static Freetype installation. CMake's [Freetype find module](https://github.com/Kitware/CMake/blob/v2.8.8/Modules/FindFreetype.cmake) doesn't provide any info about whether Freetype was built as shared or static, nor which dependencies it was built with, so instead I check the library name for `dll`, `so`, or `dylib` to find out - falsely assuming it is static is mostly harmless. Unfortunately there's no easy way to check which dependencies it needs, so I just pull in all of them as optional and leave it to the user to configure them properly if needed.

Part of the motivation for this is that using Visual Studio to build Freetype as a shared library is a pain to do - Freetype's `CMakeLists.txt` actually has a check that ensures only MinGW can be used for creating a shared library on Windows, so instead you have to [work around it by hand](http://stackoverflow.com/a/7387618/1959975). It would be nice if instead we could ignore all that and just build it statically on Windows.