### PR TITLE
More Platforms on AppVeyor

### DIFF
--- a/package/ci/appveyor-desktop-amd64.bat
+++ b/package/ci/appveyor-desktop-amd64.bat
@@ -1,0 +1,59 @@
+call "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat" amd64 || exit /b
+set PATH=%APPVEYOR_BUILD_FOLDER%/openal/bin/Win64;%APPVEYOR_BUILD_FOLDER%\deps\bin;%PATH%
+
+rem Build Corrade
+git clone --depth 1 git://github.com/mosra/corrade.git || exit /b
+cd corrade || exit /b
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DWITH_INTERCONNECT=OFF ^
+    -G Ninja || exit /b
+cmake --build . || exit /b
+cmake --build . --target install || exit /b
+cd .. && cd ..
+
+rem Build Magnum
+git clone --depth 1 git://github.com/mosra/magnum.git || exit /b
+cd magnum || exit /b
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%/openal" ^
+    -DWITH_AUDIO=ON ^
+    -DWITH_WINDOWLESSWGLAPPLICATION=ON ^
+    -DWITH_WGLCONTEXT=ON ^
+    -DWITH_MAGNUMFONT=ON ^
+    -DWITH_MAGNUMFONTCONVERTER=ON ^
+    -DWITH_OBJIMPORTER=ON ^
+    -DWITH_TGAIMAGECONVERTER=ON ^
+    -DWITH_TGAIMPORTER=ON ^
+    -DWITH_WAVAUDIOIMPORTER=ON ^
+    -DWITH_DISTANCEFIELDCONVERTER=ON ^
+    -DWITH_FONTCONVERTER=ON ^
+    -G Ninja || exit /b
+cmake --build . || exit /b
+cmake --build . --target install || exit /b
+cd .. && cd ..
+
+rem Build LibJPEG Turbo
+cd libjpeg-turbo
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G Ninja
+cmake --build .
+cmake --build . --target install
+cd .. && cd ..
+
+rem Build
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/openal -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_FREETYPEFONT=OFF -DWITH_HARFBUZZFONT=OFF -DWITH_JPEGIMPORTER=ON -DWITH_MINIEXRIMAGECONVERTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMAGECONVERTER=OFF -DWITH_PNGIMPORTER=OFF -DWITH_STANFORDIMPORTER=ON -DWITH_STBIMAGEIMPORTER=ON -DWITH_STBPNGIMAGECONVERTER=ON -DWITH_STBTRUETYPEFONT=ON -DWITH_STBVORBISAUDIOIMPORTER=ON -DBUILD_TESTS=ON -DBUILD_GL_TESTS=ON -G Ninja
+cmake --build .
+cmake --build . --target install
+cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
+cmake --build . --target install
+cd ../Deploy
+7z a ../magnum-plugins.zip *

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -1,0 +1,61 @@
+rem Workaround for CMake not wanting sh.exe on PATH for MinGW. AARGH.
+set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+set PATH=C:\tools\mingw64\bin;%APPVEYOR_BUILD_FOLDER%/openal/bin/Win64;%APPVEYOR_BUILD_FOLDER%\deps\bin;%PATH%
+
+rem Build Corrade. Could not get Ninja to work, meh.
+git clone --depth 1 git://github.com/mosra/corrade.git || exit /b
+cd corrade || exit /b
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DWITH_INTERCONNECT=OFF ^
+    -G "MinGW Makefiles" || exit /b
+cmake --build . -- -j || exit /b
+cmake --build . --target install -- -j || exit /b
+cd .. && cd ..
+
+rem Build
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%/openal" ^
+    -DWITH_AUDIO=ON ^
+    -DWITH_WINDOWLESSWGLAPPLICATION=ON ^
+    -DWITH_WGLCONTEXT=ON ^
+    -DWITH_MAGNUMFONT=ON ^
+    -DWITH_MAGNUMFONTCONVERTER=ON ^
+    -DWITH_OBJIMPORTER=ON ^
+    -DWITH_TGAIMAGECONVERTER=ON ^
+    -DWITH_TGAIMPORTER=ON ^
+    -DWITH_WAVAUDIOIMPORTER=ON ^
+    -DWITH_DISTANCEFIELDCONVERTER=ON ^
+    -DWITH_FONTCONVERTER=ON ^
+    -G "MinGW Makefiles" || exit /b
+cmake --build . || exit /b
+cmake --build . --target install || exit /b
+cd .. && cd ..
+
+rem Build LibJPEG Turbo
+cd libjpeg-turbo
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G Ninja
+cmake --build .
+cmake --build . --target install
+cd .. && cd ..
+
+rem Build
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/openal -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_FREETYPEFONT=OFF -DWITH_HARFBUZZFONT=OFF -DWITH_JPEGIMPORTER=ON -DWITH_MINIEXRIMAGECONVERTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMAGECONVERTER=OFF -DWITH_PNGIMPORTER=OFF -DWITH_STANFORDIMPORTER=ON -DWITH_STBIMAGEIMPORTER=ON -DWITH_STBPNGIMAGECONVERTER=ON -DWITH_STBTRUETYPEFONT=ON -DWITH_STBVORBISAUDIOIMPORTER=ON -DBUILD_TESTS=ON -DBUILD_GL_TESTS=ON -G Ninja
+cmake --build .
+cmake --build . --target install
+cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
+cmake --build . --target install
+cd ../Deploy
+7z a ../magnum-plugins.zip *
+
+rem Test
+ctest -V -E GLTest || exit /b

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -58,6 +58,3 @@ cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
 cmake --build . --target install
 cd ../Deploy
 7z a ../magnum-plugins.zip *
-
-rem Test
-ctest -V -E GLTest || exit /b

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -43,7 +43,7 @@ rem Build LibJPEG Turbo
 cd libjpeg-turbo
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G Ninja
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G "MinGW Makefiles"
 cmake --build .
 cmake --build . --target install
 cd .. && cd ..

--- a/package/ci/appveyor-desktop-mingw.bat
+++ b/package/ci/appveyor-desktop-mingw.bat
@@ -15,7 +15,9 @@ cmake --build . -- -j || exit /b
 cmake --build . --target install -- -j || exit /b
 cd .. && cd ..
 
-rem Build
+rem Build Magnum
+git clone --depth 1 git://github.com/mosra/magnum.git || exit /b
+cd magnum || exit /b
 mkdir build && cd build || exit /b
 cmake .. ^
     -DCMAKE_BUILD_TYPE=Release ^

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -1,0 +1,60 @@
+call "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat" || exit /b
+set PATH=%APPVEYOR_BUILD_FOLDER%/openal/bin/Win32;%APPVEYOR_BUILD_FOLDER%\deps\bin;%PATH%
+
+rem Build Corrade
+git clone --depth 1 git://github.com/mosra/corrade.git || exit /b
+cd corrade || exit /b
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DWITH_INTERCONNECT=OFF ^
+    -G Ninja || exit /b
+cmake --build . || exit /b
+cmake --build . --target install || exit /b
+cd .. && cd ..
+
+rem Build Magnum
+mkdir build && cd build || exit /b
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/deps ^
+    -DCMAKE_PREFIX_PATH="%APPVEYOR_BUILD_FOLDER%/openal" ^
+    -DWITH_AUDIO=ON ^
+    -DWITH_WINDOWLESSWGLAPPLICATION=ON ^
+    -DWITH_WGLCONTEXT=ON ^
+    -DWITH_MAGNUMFONT=ON ^
+    -DWITH_MAGNUMFONTCONVERTER=ON ^
+    -DWITH_OBJIMPORTER=ON ^
+    -DWITH_TGAIMAGECONVERTER=ON ^
+    -DWITH_TGAIMPORTER=ON ^
+    -DWITH_WAVAUDIOIMPORTER=ON ^
+    -DWITH_DISTANCEFIELDCONVERTER=ON ^
+    -DWITH_FONTCONVERTER=ON ^
+    -G Ninja || exit /b
+cmake --build . || exit /b
+cmake --build . --target install || exit /b
+cd .. && cd ..
+
+rem Build LibJPEG Turbo
+cd libjpeg-turbo
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G Ninja
+cmake --build .
+cmake --build . --target install
+cd .. && cd ..
+
+rem Build
+mkdir build
+cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/openal -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_FREETYPEFONT=OFF -DWITH_HARFBUZZFONT=OFF -DWITH_JPEGIMPORTER=ON -DWITH_MINIEXRIMAGECONVERTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMAGECONVERTER=OFF -DWITH_PNGIMPORTER=OFF -DWITH_STANFORDIMPORTER=ON -DWITH_STBIMAGEIMPORTER=ON -DWITH_STBPNGIMAGECONVERTER=ON -DWITH_STBTRUETYPEFONT=ON -DWITH_STBVORBISAUDIOIMPORTER=ON -DBUILD_TESTS=ON -DBUILD_GL_TESTS=ON -G Ninja
+cmake --build .
+cmake --build . --target install
+cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
+cmake --build . --target install
+cd ../Deploy
+7z a ../magnum-plugins.zip *
+
+rem Test
+ctest -V -E GLTest || exit /b

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -57,6 +57,3 @@ cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
 cmake --build . --target install
 cd ../Deploy
 7z a ../magnum-plugins.zip *
-
-rem Test
-ctest -V -E GLTest || exit /b

--- a/package/ci/appveyor-desktop.bat
+++ b/package/ci/appveyor-desktop.bat
@@ -15,6 +15,8 @@ cmake --build . --target install || exit /b
 cd .. && cd ..
 
 rem Build Magnum
+git clone --depth 1 git://github.com/mosra/magnum.git || exit /b
+cd magnum || exit /b
 mkdir build && cd build || exit /b
 cmake .. ^
     -DCMAKE_BUILD_TYPE=Release ^

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -44,3 +44,11 @@ build_script:
 cache:
 - openal-soft-1.17.2-bin.zip
 - libjpeg-turbo-1.2.0.tar.gz
+
+test_script:
+- cd %APPVEYOR_BUILD_FOLDER%/build
+- SET fail=0
+- ctest --output-on-failure -E GLTest || SET fail=1 & ver > nul
+- cd %APPVEYOR_BUILD_FOLDER%
+- appveyor PushArtifact magnum-plugins.zip
+- exit %fail%

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -1,12 +1,17 @@
 # kate: indent-width 2;
 
-version: '{branch}-{build}'
-
 skip_tags: true
 shallow_clone: true
 clone_depth: 1
 
 os: Visual Studio 2015
+
+environment:
+  matrix:
+  - TARGET: desktop
+    COMPILER: msvc
+  - TARGET: desktop
+    COMPILER: mingw
 
 notifications:
 - provider: Webhook
@@ -16,73 +21,26 @@ notifications:
   on_build_status_changed: true
 
 install:
-- call "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat"
-- set PATH=C:/Sys/bin;C:/tools/ninja;%APPVEYOR_BUILD_FOLDER%/openal/bin/Win32;%PATH%
-
-# Ninja
 - cinst ninja
+- set PATH=C:/tools/ninja;%PATH%
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "mingw" cinst mingw /f >nul
 
 # OpenAL
-- IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\openal-soft-1.17.2-bin.zip appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.2-bin.zip
-- 7z x openal-soft-1.17.2-bin.zip
-- ren openal-soft-1.17.2-bin openal
-- ren openal\bin\Win32\soft_oal.dll OpenAL32.dll
+- IF NOT "%TARGET%" == "rt" IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\openal-soft-1.17.2-bin.zip appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.2-bin.zip
+- IF NOT "%TARGET%" == "rt" 7z x openal-soft-1.17.2-bin.zip && ren openal-soft-1.17.2-bin openal && echo [General] > %APPDATA%/alsoft.ini & echo drivers=null >> %APPDATA%/alsoft.ini
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" ren openal\bin\Win32\soft_oal.dll OpenAL32.dll
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "mingw" ren openal\bin\Win64\soft_oal.dll OpenAL32.dll
 
 # LibJPEG Turbo
 - IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\libjpeg-turbo-1.2.0.tar.gz appveyor DownloadFile http://downloads.sourceforge.net/project/libjpeg-turbo/1.2.0/libjpeg-turbo-1.2.0.tar.gz
 - 7z x libjpeg-turbo-1.2.0.tar.gz
 - 7z x libjpeg-turbo-1.2.0.tar
 - ren libjpeg-turbo-1.2.0 libjpeg-turbo
-- cd libjpeg-turbo
-- mkdir build
-- cd build
-- cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DWITH_JPEG8=ON -DWITH_SIMD=OFF -G Ninja
-- cmake --build .
-- cmake --build . --target install
-- cd ..
-- cd ..
 
-# Corrade
-- git clone --depth 1 git://github.com/mosra/corrade.git
-- cd corrade
-- mkdir build
-- cd build
-- cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -G Ninja
-- cmake --build .
-- cmake --build . --target install
-- cd ..
-- cd ..
-
-# Magnum
-- git clone --depth 1 git://github.com/mosra/magnum.git
-- cd magnum
-- mkdir build
-- cd build
-- cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/openal -DWITH_AUDIO=ON -DWITH_DEBUGTOOLS=OFF -DWITH_PRIMITIVES=OFF -DWITH_SCENEGRAPH=OFF -DWITH_SHADERS=OFF -DWITH_SHAPES=OFF -DWITH_TEXT=ON -DWITH_TEXTURETOOLS=ON -DWITH_WINDOWLESSWGLAPPLICATION=ON -G Ninja
-- cmake --build .
-- cmake --build . --target install
-- cd ..
-- cd ..
+build_script:
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" call package\ci\appveyor-desktop.bat
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "mingw" call package\ci\appveyor-desktop-mingw.bat
 
 cache:
 - openal-soft-1.17.2-bin.zip
 - libjpeg-turbo-1.2.0.tar.gz
-
-build_script:
-- mkdir build
-- cd build
-- cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:/Sys -DCMAKE_PREFIX_PATH=%APPVEYOR_BUILD_FOLDER%/openal -DWITH_ANYAUDIOIMPORTER=ON -DWITH_ANYIMAGECONVERTER=ON -DWITH_ANYIMAGEIMPORTER=ON -DWITH_ANYSCENEIMPORTER=ON -DWITH_DDSIMPORTER=ON -DWITH_FREETYPEFONT=OFF -DWITH_HARFBUZZFONT=OFF -DWITH_JPEGIMPORTER=ON -DWITH_MINIEXRIMAGECONVERTER=ON -DWITH_OPENGEXIMPORTER=ON -DWITH_PNGIMAGECONVERTER=OFF -DWITH_PNGIMPORTER=OFF -DWITH_STANFORDIMPORTER=ON -DWITH_STBIMAGEIMPORTER=ON -DWITH_STBPNGIMAGECONVERTER=ON -DWITH_STBTRUETYPEFONT=ON -DWITH_STBVORBISAUDIOIMPORTER=ON -DBUILD_TESTS=ON -DBUILD_GL_TESTS=ON -G Ninja
-- cmake --build .
-- cmake --build . --target install
-- cmake . -DCMAKE_INSTALL_PREFIX=%APPVEYOR_BUILD_FOLDER%/Deploy -DBUILD_TESTS=OFF
-- cmake --build . --target install
-- cd ../Deploy
-- 7z a ../magnum-plugins.zip *
-
-test_script:
-- cd %APPVEYOR_BUILD_FOLDER%/build
-- SET fail=0
-- ctest --output-on-failure -E GLTest || SET fail=1 & ver > nul
-- cd %APPVEYOR_BUILD_FOLDER%
-- appveyor PushArtifact magnum-plugins.zip
-- exit %fail%

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -10,8 +10,13 @@ environment:
   matrix:
   - TARGET: desktop
     COMPILER: msvc
+    ARCHITECTURE: x86
+  - TARGET: desktop
+    COMPILER: msvc
+    ARCHITECTURE: amd64
   - TARGET: desktop
     COMPILER: mingw
+    ARCHITECTURE: amd64
 
 notifications:
 - provider: Webhook
@@ -28,8 +33,8 @@ install:
 # OpenAL
 - IF NOT "%TARGET%" == "rt" IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\openal-soft-1.17.2-bin.zip appveyor DownloadFile http://kcat.strangesoft.net/openal-binaries/openal-soft-1.17.2-bin.zip
 - IF NOT "%TARGET%" == "rt" 7z x openal-soft-1.17.2-bin.zip && ren openal-soft-1.17.2-bin openal && echo [General] > %APPDATA%/alsoft.ini & echo drivers=null >> %APPDATA%/alsoft.ini
-- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" ren openal\bin\Win32\soft_oal.dll OpenAL32.dll
-- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "mingw" ren openal\bin\Win64\soft_oal.dll OpenAL32.dll
+- IF "%ARCHITECTURE%" == "x86" ren openal\bin\Win32\soft_oal.dll OpenAL32.dll
+- IF "%ARCHITECTURE%" == "amd64" ren openal\bin\Win64\soft_oal.dll OpenAL32.dll
 
 # LibJPEG Turbo
 - IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\libjpeg-turbo-1.2.0.tar.gz appveyor DownloadFile http://downloads.sourceforge.net/project/libjpeg-turbo/1.2.0/libjpeg-turbo-1.2.0.tar.gz
@@ -38,7 +43,8 @@ install:
 - ren libjpeg-turbo-1.2.0 libjpeg-turbo
 
 build_script:
-- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" call package\ci\appveyor-desktop.bat
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" IF "%ARCHITECTURE%" == "amd64" call package\ci\appveyor-desktop-amd64.bat
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" IF "%ARCHITECTURE%" == "x86" call package\ci\appveyor-desktop.bat
 - IF "%TARGET%" == "desktop" IF "%COMPILER%" == "mingw" call package\ci\appveyor-desktop-mingw.bat
 
 cache:


### PR DESCRIPTION
Hi @mosra !

I am secretly trying to get AppVeyor to build magnum-plugins with msvc amd64 (see gitter).
As a result, mingw-w64 platform has been added to get the neat structure which you established on mosra/magnum :)

If having all these platforms on magnum-plugins aswell is not desired, you may reject the PR (once I'm done testing msvc amd64, heh ;) )

Regards, Squareys.