### PR TITLE
OpenGexImporter: Fix light import

### DIFF
--- a/src/MagnumPlugins/OpenGexImporter/OpenGexImporter.cpp
+++ b/src/MagnumPlugins/OpenGexImporter/OpenGexImporter.cpp
@@ -517,7 +517,7 @@ std::optional<LightData> OpenGexImporter::doLight(UnsignedInt id) {
         }
 
         const auto attrib = color.propertyOf(OpenGex::attrib);
-        if(attrib.as<std::string>() == "color") {
+        if(attrib.as<std::string>() == "light") {
             lightColor = extractColorData<Color3>(floatArray);
         } else {
             Error() << "Trade::OpenGexImporter::light(): invalid color";

--- a/src/MagnumPlugins/OpenGexImporter/Test/light.ogex
+++ b/src/MagnumPlugins/OpenGexImporter/Test/light.ogex
@@ -3,7 +3,7 @@ LightObject (type = "infinite") {
         float { 3.0 }
     }
 
-    Color (attrib = "color") {
+    Color (attrib = "light") {
         float[3] { { 0.7, 1.0, 0.1 } }
     }
 }
@@ -15,7 +15,7 @@ LightObject (type = "point") {
 }
 
 LightObject (type = "spot") {
-    Color (attrib = "color") {
+    Color (attrib = "light") {
         float[4] { { 0.1, 0.0, 0.1, 1.0 } }
     }
 }


### PR DESCRIPTION
Good morning @mosra ! :)

As discussed, here is the PR that changes the "color" to "light" to match the ogex specs.

Regars, Jonathan.