### PR TITLE
Add include directory based on CMAKE variables to assimp

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/CMakeLists.txt
+++ b/src/MagnumPlugins/AssimpImporter/CMakeLists.txt
@@ -49,6 +49,7 @@ target_include_directories(AssimpImporterObjects PUBLIC
     ${PROJECT_SOURCE_DIR}/src
     ${PROJECT_BINARY_DIR}/src)
 target_compile_definitions(AssimpImporterObjects PRIVATE "AssimpImporterObjects_EXPORTS")
+target_include_directories(AssimpImporterObjects SYSTEM PRIVATE ${ASSIMP_INCLUDE_DIR})
 if(NOT BUILD_STATIC OR BUILD_STATIC_PIC)
     set_target_properties(AssimpImporterObjects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()


### PR DESCRIPTION
Looks like someone missed the ASSIMP_INCLUDE_DIR variable :-1: 