### PR TITLE
Add openState feature to AssimpImporter

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
@@ -85,7 +85,7 @@ AssimpImporter::AssimpImporter(PluginManager::AbstractManager& manager, const st
 
 AssimpImporter::~AssimpImporter() = default;
 
-auto AssimpImporter::doFeatures() const -> Features { return Feature::OpenData; }
+auto AssimpImporter::doFeatures() const -> Features { return Feature::OpenData | Feature::OpenState; }
 
 bool AssimpImporter::doIsOpened() const { return _f && _f->_scene; }
 
@@ -162,6 +162,14 @@ void AssimpImporter::doOpenData(const Containers::ArrayView<const char> data) {
             _f->_nodeInstances[lightNode] = {ObjectInstanceType3D::Light, i};
         }
     }
+}
+
+void AssimpImporter::doOpenState(const void* state, const std::string& filePath) {
+    _f.reset(new File);
+    _f->_scene = static_cast<const aiScene*>(state);
+    _f->_filePath = filePath;
+
+    doOpenData({});
 }
 
 void AssimpImporter::doOpenFile(const std::string& filename) {

--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.h
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.h
@@ -163,6 +163,8 @@ importer state methods:
     -   @ref LightData::importerState() returns `aiLight`
     -   @ref ImageData2D::importerState() may return `aiTexture`, if texture was embedded
         into the loaded file.
+-   @ref openState() expects a pointer to an Assimp scene (i.e., `const aiScene*`)
+    and optionally a path (in order to be able to load textures, if needed)
 
 @todo There are more formats mentioned at http://assimp.sourceforge.net/main_features_formats.html, add aliases for them?
 */
@@ -196,6 +198,7 @@ class MAGNUM_TRADE_ASSIMPIMPORTER_EXPORT AssimpImporter: public AbstractImporter
 
         MAGNUM_TRADE_ASSIMPIMPORTER_LOCAL bool doIsOpened() const override;
         MAGNUM_TRADE_ASSIMPIMPORTER_LOCAL void doOpenData(Containers::ArrayView<const char> data) override;
+        MAGNUM_TRADE_ASSIMPIMPORTER_LOCAL void doOpenState(const void* state, const std::string& filePath) override;
         MAGNUM_TRADE_ASSIMPIMPORTER_LOCAL void doOpenFile(const std::string& filename) override;
         MAGNUM_TRADE_ASSIMPIMPORTER_LOCAL void doClose() override;
 

--- a/src/MagnumPlugins/AssimpImporter/Test/Test.cpp
+++ b/src/MagnumPlugins/AssimpImporter/Test/Test.cpp
@@ -186,7 +186,7 @@ void AssimpImporterTest::lightUndefined() {
 
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* @todo Possibly works with earlier versions (definitely not 3.0) */
-    if(version < 303)
+    if(version < 302)
         CORRADE_SKIP("Current version of assimp cannot load lights with undefined light type yet.");
 
     std::ostringstream out;
@@ -215,7 +215,7 @@ void AssimpImporterTest::material() {
 
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* Ancient assimp version add "-material" suffix */
-    if(version < 303) {
+    if(version < 302) {
         CORRADE_COMPARE(importer.materialForName("Material-material"), 0);
         CORRADE_COMPARE(importer.materialName(0), "Material-material");
     } else {
@@ -248,7 +248,7 @@ void AssimpImporterTest::mesh() {
             {0.5f, 1.0f}, {0.75f, 0.5f}, {0.5f, 0.9f}}));
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* Skip for assimp < 3.3, which loads some incorrect alpha value for the last color */
-    if(version >= 303) {
+    if(version >= 302) {
         CORRADE_COMPARE(mesh->colors(0), (std::vector<Color4>{
             {1.0f, 0.25f, 0.24f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}, {0.1f, 0.2f, 0.3f, 1.0f}}));
     }
@@ -342,7 +342,7 @@ void AssimpImporterTest::scene() {
 void AssimpImporterTest::texture() {
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* @todo Possibly works with earlier versions (definitely not 3.0) */
-    if(version < 303)
+    if(version < 302)
         CORRADE_SKIP("Current version of assimp would SEGFAULT on this test.");
 
 
@@ -385,7 +385,7 @@ void AssimpImporterTest::embeddedTexture() {
 
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* @todo Possibly works with earlier versions (definitely not 3.0) */
-    if(version < 303)
+    if(version < 302)
         CORRADE_SKIP("Current version of assimp cannot load embedded textures from blender files.");
 
     CORRADE_COMPARE(importer.textureCount(), 1);
@@ -448,7 +448,7 @@ void AssimpImporterTest::openState() {
 void AssimpImporterTest::openStateTexture() {
     const UnsignedInt version = aiGetVersionMajor()*100 + aiGetVersionMinor();
     /* @todo Possibly works with earlier versions (definitely not 3.0) */
-    if(version < 303)
+    if(version < 302)
         CORRADE_SKIP("Current version of assimp would SEGFAULT on this test.");
 
 


### PR DESCRIPTION
This PR adds the `openState` feature to `AssimpImporter` in order to be able to import an `aiScene`.