### PR TITLE
FreeType: reset library variable during finalize()

### DIFF
--- a/src/MagnumPlugins/FreeTypeFont/FreeTypeFont.cpp
+++ b/src/MagnumPlugins/FreeTypeFont/FreeTypeFont.cpp
@@ -63,6 +63,7 @@ void FreeTypeFont::initialize() {
 void FreeTypeFont::finalize() {
     CORRADE_INTERNAL_ASSERT(library);
     CORRADE_INTERNAL_ASSERT_OUTPUT(FT_Done_FreeType(library) == 0);
+    library = nullptr;
 }
 
 FreeTypeFont::FreeTypeFont(): ftFont(nullptr) {}


### PR DESCRIPTION
By not resetting the `library` variable, we can't safely initialize twice FreeType in the lifetime of the application.