### PR TITLE
package/msys: Add PKGBUILDs.

### DIFF
--- a/package/msys/.gitattributes
+++ b/package/msys/.gitattributes
@@ -1,0 +1,2 @@
+magnum/PKGBUILD text eof=lf
+PKGBUILD text eof=lf

--- a/package/msys/.gitattributes
+++ b/package/msys/.gitattributes
@@ -1,2 +1,2 @@
-magnum/PKGBUILD text eof=lf
+magnum-plugins/PKGBUILD text eof=lf
 PKGBUILD text eof=lf

--- a/package/msys/PKGBUILD
+++ b/package/msys/PKGBUILD
@@ -1,0 +1,62 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the packages/archlinux/PKGBUILD file by mosra <mosra@centrum.cz> and the MSYS2/MinGW PKGBUILD templates
+
+_realname=magnum-plugins
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=dev
+pkgrel=1
+pkgdesc="Plugins for the Magnum C++11/C++14 graphics engine"
+arch=('any')
+url="https://magnum.graphics/"
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-magnum>=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-assimp"
+         "${MINGW_PACKAGE_PREFIX}-devil"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-faad2"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja")
+options=('!strip')
+
+_rootdir=$startdir/../../
+
+build() {
+    mkdir -p "$_rootdir/build-${CARCH}"
+    cd "$_rootdir/build-${CARCH}"
+
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake .. \
+            -G'Ninja' \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            -DWITH_ASSIMPIMPORTER=OFF \
+            -DWITH_DDSIMPORTER=ON \
+            -DWITH_DEVILIMAGEIMPORTER=ON \
+            -DWITH_DRFLACAUDIOIMPORTER=ON \
+            -DWITH_DRWAVAUDIOIMPORTER=ON \
+            -DWITH_FAAD2AUDIOIMPORTER=ON \
+            -DWITH_FREETYPEFONT=ON \
+            -DWITH_HARFBUZZFONT=ON \
+            -DWITH_JPEGIMAGECONVERTER=ON \
+            -DWITH_JPEGIMPORTER=ON \
+            -DWITH_MINIEXRIMAGECONVERTER=ON \
+            -DWITH_PNGIMAGECONVERTER=ON \
+            -DWITH_PNGIMPORTER=ON \
+            -DWITH_OPENGEXIMPORTER=ON \
+            -DWITH_STANFORDIMPORTER=ON \
+            -DWITH_STBIMAGECONVERTER=ON \
+            -DWITH_STBIMAGEIMPORTER=ON \
+            -DWITH_STBTRUETYPEFONT=ON \
+            -DWITH_STBVORBISAUDIOIMPORTER=ON \
+            -DWITH_TINYGLTFIMPORTER=ON
+    ninja
+}
+
+package() {
+    cd "$_rootdir/build-${CARCH}"
+    DESTDIR="${pkgdir}" ninja install
+}

--- a/package/msys/magnum-plugins/PKGBUILD
+++ b/package/msys/magnum-plugins/PKGBUILD
@@ -15,6 +15,7 @@ depends=("${MINGW_PACKAGE_PREFIX}-magnum>=$pkgver"
          "${MINGW_PACKAGE_PREFIX}-assimp"
          "${MINGW_PACKAGE_PREFIX}-devil"
          "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-harfbuzz"
          "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
          "${MINGW_PACKAGE_PREFIX}-libpng")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
@@ -45,6 +46,7 @@ build() {
             -DWITH_DRFLACAUDIOIMPORTER=ON \
             -DWITH_DRWAVAUDIOIMPORTER=ON \
             -DWITH_FREETYPEFONT=ON \
+            -DWITH_HARFBUZZFONT=ON \
             -DWITH_JPEGIMAGECONVERTER=ON \
             -DWITH_JPEGIMPORTER=ON \
             -DWITH_MINIEXRIMAGECONVERTER=ON \

--- a/package/msys/magnum-plugins/PKGBUILD
+++ b/package/msys/magnum-plugins/PKGBUILD
@@ -1,0 +1,71 @@
+# Author: williamjcm <w.jcm59@gmail.com>
+# Contributor: mosra <mosra@centrum.cz>
+# Based on the magnum-plugins Arch Linux PKGBUILD maintained by xyproto and the MSYS2/MinGW PKGBUILD templates
+
+_realname=magnum-plugins
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2018.10
+pkgrel=1
+pkgdesc='Plugins for the Magnum C++11/C++14 graphics engine'
+arch=('any')
+url='https://magnum.graphics/'
+license=('MIT')
+depends=("${MINGW_PACKAGE_PREFIX}-magnum>=$pkgver"
+         "${MINGW_PACKAGE_PREFIX}-assimp"
+         "${MINGW_PACKAGE_PREFIX}-devil"
+         "${MINGW_PACKAGE_PREFIX}-freetype"
+         "${MINGW_PACKAGE_PREFIX}-libjpeg-turbo"
+         "${MINGW_PACKAGE_PREFIX}-libpng")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake" "${MINGW_PACKAGE_PREFIX}-ninja" 'git')
+# The .tar.gz / .zip download contains symlinks (.travis.yml), making tar and
+# unzip on Windows grumpy because dangling symlinks are created. Could be fixed
+# by manually extracting everything except symlinks, but that's hard to
+# maintain. Downloading a Git tag works.
+source=("${_realname}-${pkgver}"::"git+https://github.com/mosra/magnum-plugins.git#tag=v$pkgver")
+sha1sums=('SKIP')
+
+build() {
+    mkdir -p "${srcdir}"/build-${CARCH} && cd "${srcdir}"/build-${CARCH}
+
+    declare -a extra_config
+    if check_option "debug" "n"; then
+        extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+    else
+        extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+    fi
+    
+    MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+        ${MINGW_PREFIX}/bin/cmake \
+            -G'Ninja' \
+            -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+            -DWITH_ASSIMPIMPORTER=OFF \
+            -DWITH_DDSIMPORTER=ON \
+            -DWITH_DEVILIMAGEIMPORTER=ON \
+            -DWITH_DRFLACAUDIOIMPORTER=ON \
+            -DWITH_DRWAVAUDIOIMPORTER=ON \
+            -DWITH_FREETYPEFONT=ON \
+            -DWITH_JPEGIMAGECONVERTER=ON \
+            -DWITH_JPEGIMPORTER=ON \
+            -DWITH_MINIEXRIMAGECONVERTER=ON \
+            -DWITH_PNGIMAGECONVERTER=ON \
+            -DWITH_PNGIMPORTER=ON \
+            -DWITH_OPENGEXIMPORTER=ON \
+            -DWITH_STANFORDIMPORTER=ON \
+            -DWITH_STBIMAGECONVERTER=ON \
+            -DWITH_STBIMAGEIMPORTER=ON \
+            -DWITH_STBTRUETYPEFONT=ON \
+            -DWITH_STBVORBISAUDIOIMPORTER=ON \
+            -DWITH_TINYGLTFIMPORTER=ON \
+            "${extra_config[@]}" \
+            ../${_realname}-${pkgver}
+    ninja
+}
+
+package() {
+    cd "${srcdir}"/build-${CARCH}
+    DESTDIR="${pkgdir}" ninja install
+
+    install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" \
+        "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
And associated `.gitattributes` file.

Once again, comments and feedback are welcome! While mosra/corrade#56 and mosra/magnum#307 allowed me to do less mistakes this time, there might still be a few issues remaining.