### PR TITLE
JpegImporter: redirect libjpeg errors to Corrade::Utility::Error

### DIFF
--- a/src/MagnumPlugins/JpegImporter/JpegImporter.cpp
+++ b/src/MagnumPlugins/JpegImporter/JpegImporter.cpp
@@ -73,7 +73,9 @@ Containers::Optional<ImageData2D> JpegImporter::doImage2D(UnsignedInt) {
     } errorManager;
     file.err = jpeg_std_error(&errorManager.jpegErrorManager);
     errorManager.jpegErrorManager.error_exit = [](j_common_ptr info) {
-        info->err->output_message(info);
+        char buffer[JMSG_LENGTH_MAX];
+        info->err->format_message(info, buffer);
+        Error{} << buffer;
         std::longjmp(reinterpret_cast<ErrorManager*>(info->err)->setjmpBuffer, 1);
     };
     if(setjmp(errorManager.setjmpBuffer)) {


### PR DESCRIPTION
I'm crawling a large dataset with a few faulty JPEGs - which I would like to ignore silently. However, `libjpeg` errors are currently directly printed to `stderr`. This PR redirects them to `Corrage::Utility::Error`, which can then be redirected by the user to capture any errors that might occur.