### PR TITLE
AssimpImporter: populate right texture indices

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
+++ b/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
@@ -417,7 +417,8 @@ void AssimpImporterTest::materialAmbientDiffuseTexture() {
 
     Trade::PhongMaterialData* phongMaterial = static_cast<Trade::PhongMaterialData*>(material.get());
     CORRADE_VERIFY(phongMaterial);
-    CORRADE_COMPARE(phongMaterial->flags(), Trade::PhongMaterialData::AmbientTexture | Trade::PhongMaterialData::DiffuseTexture);
+    CORRADE_COMPARE(phongMaterial->flags(), Trade::PhongMaterialData::Flag::AmbientTexture |
+        Trade::PhongMaterialData::Flag::DiffuseTexture);
     CORRADE_COMPARE(phongMaterial->ambientTexture(), 0);
     CORRADE_COMPARE(phongMaterial->diffuseTexture(), 1);
 }

--- a/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
+++ b/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
@@ -91,6 +91,7 @@ struct AssimpImporterTest: TestSuite::Tester {
     void material();
     void materialStlWhiteAmbientPatch();
     void materialWhiteAmbientTexture();
+    void materialAmbientDiffuseTexture();
 
     void mesh();
     void pointMesh();
@@ -155,6 +156,7 @@ AssimpImporterTest::AssimpImporterTest() {
               &AssimpImporterTest::material,
               &AssimpImporterTest::materialStlWhiteAmbientPatch,
               &AssimpImporterTest::materialWhiteAmbientTexture,
+              &AssimpImporterTest::materialAmbientDiffuseTexture,
 
               &AssimpImporterTest::mesh,
               &AssimpImporterTest::pointMesh,
@@ -402,6 +404,22 @@ void AssimpImporterTest::materialWhiteAmbientTexture() {
     CORRADE_COMPARE(static_cast<PhongMaterialData&>(*material).flags(), PhongMaterialData::Flag::AmbientTexture);
     /* It shouldn't be complaining about white ambient in this case */
     CORRADE_COMPARE(out.str(), "");
+}
+
+void AssimpImporterTest::materialAmbientDiffuseTexture() {
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("AssimpImporter");
+    CORRADE_VERIFY(importer->openFile(Utility::Directory::join(ASSIMPIMPORTER_TEST_DIR, "texture-ambient-diffuse.dae")));
+
+    CORRADE_COMPARE(importer->materialCount(), 1);
+    Containers::Pointer<Trade::AbstractMaterialData> material = importer->material(0);
+    CORRADE_VERIFY(material);
+    CORRADE_COMPARE(material->type(), MaterialType::Phong);
+
+    Trade::PhongMaterialData* phongMaterial = static_cast<Trade::PhongMaterialData*>(material.get());
+    CORRADE_VERIFY(phongMaterial);
+    CORRADE_COMPARE(phongMaterial->flags(), Trade::PhongMaterialData::AmbientTexture | Trade::PhongMaterialData::DiffuseTexture);
+    CORRADE_COMPARE(phongMaterial->ambientTexture(), 0);
+    CORRADE_COMPARE(phongMaterial->diffuseTexture(), 1);
 }
 
 void AssimpImporterTest::mesh() {

--- a/src/MagnumPlugins/AssimpImporter/Test/texture-ambient-diffuse.dae
+++ b/src/MagnumPlugins/AssimpImporter/Test/texture-ambient-diffuse.dae
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <library_images>
+    <image id="ambient_texture" name="ambient_texture">
+      <init_from>diffuse_texture.png</init_from>
+    </image>
+    <image id="diffuse_texture" name="diffuse_texture">
+      <init_from>diffuse_texture.png</init_from>
+    </image>
+  </library_images>
+  <library_effects>
+    <effect id="Material-effect">
+      <profile_COMMON>
+        <newparam sid="ambient_texture-surface">
+          <surface type="2D">
+            <init_from>ambient_texture</init_from>
+          </surface>
+        </newparam>
+        <newparam sid="ambient_texture-sampler">
+          <sampler2D>
+            <source>ambient_texture-surface</source>
+          </sampler2D>
+        </newparam>
+        <newparam sid="diffuse_texture-surface">
+          <surface type="2D">
+            <init_from>diffuse_texture</init_from>
+          </surface>
+        </newparam>
+        <newparam sid="diffuse_texture-sampler">
+          <sampler2D>
+            <source>diffuse_texture-surface</source>
+          </sampler2D>
+        </newparam>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <texture texture="ambient_texture-sampler"/>
+            </ambient>
+            <diffuse>
+              <texture texture="diffuse_texture-sampler"/>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.15 0.1 0.05 1</color>
+            </specular>
+            <shininess>
+              <float sid="shininess">50</float>
+            </shininess>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material-material" name="Material">
+      <instance_effect url="#Material-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube-mesh" name="Cube">
+      <mesh>
+        <source id="Cube-mesh-positions">
+          <float_array id="Cube-mesh-positions-array" count="9">-1 -1 1 -1 1 1 1 -1 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-positions-array" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-normals">
+          <float_array id="Cube-mesh-normals-array" count="3">0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-normals-array" count="1" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube-mesh-vertices">
+          <input semantic="POSITION" source="#Cube-mesh-positions"/>
+        </vertices>
+        <polylist material="Material-material" count="1">
+          <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
+          <vcount>3 </vcount>
+          <p>1 0 0 0 2 0</p>
+        </polylist>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Cube" name="Cube" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#Cube-mesh" name="Cube">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material-material" target="#Material-material"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>


### PR DESCRIPTION
Ambient/diffuse/specular texture indices are not populated in the current version. They are always 0 even a material has several textures or a model has several materials.