### PR TITLE
Make FindBasisUniversal search libraries instead of pkgconfig

### DIFF
--- a/modules/FindBasisUniversal.cmake
+++ b/modules/FindBasisUniversal.cmake
@@ -51,48 +51,6 @@
 #   DEALINGS IN THE SOFTWARE.
 #
 
-# Vcpkg distributes imgui as a library with a config file, so try that first --
-# but only if BASIS_UNIVERSAL_DIR wasn't explicitly passed, in which case we'll
-# look there instead
-find_package(basisu CONFIG QUIET)
-if(basisu_FOUND AND NOT BASIS_UNIVERSAL_DIR)
-    if(NOT TARGET BasisUniversal::Transcoder)
-        add_library(BasisUniversal::Transcoder INTERFACE IMPORTED)
-        set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES basisu_transcoder)
-
-        # Retrieve include directory for FindPackageHandleStandardArgs later
-        get_target_property(BasisUniversalTranscoder_INCLUDE_DIR basisu_transcoder
-            INTERFACE_INCLUDE_DIRECTORIES)
-    endif()
-
-    if(NOT TARGET BasisUniversal::Encoder)
-        add_library(BasisUniversal::Encoder INTERFACE IMPORTED)
-        set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
-            INTERFACE_LINK_LIBRARIES basisu_encoder)
-
-        # Retrieve include directory for FindPackageHandleStandardArgs later
-        get_target_property(BasisUniversalEncoder_INCLUDE_DIR basisu_encoder
-            INTERFACE_INCLUDE_DIRECTORIES)
-    endif()
-
-# Otherwise find the source files and compile them as part of the library they
-# get linked to
-else()
-    # Disable the find root path here, it overrides the
-    # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE setting potentially set in
-    # toolchains.
-    find_path(BasisUniversalEncoder_INCLUDE_DIR NAMES basisu_frontend.h HINTS
-        HINTS "${BASIS_UNIVERSAL_DIR}" "${BASIS_UNIVERSAL_DIR}/encoder"
-        NO_CMAKE_FIND_ROOT_PATH)
-    mark_as_advanced(BasisUniversalEncoder_INCLUDE_DIR)
-
-    find_path(BasisUniversalTranscoder_INCLUDE_DIR NAMES basisu_transcoder.h
-        HINTS "${BASIS_UNIVERSAL_DIR}/transcoder" "${BASIS_UNIVERSAL_DIR}"
-        NO_CMAKE_FIND_ROOT_PATH)
-    mark_as_advanced(BasisUniversalTranscoder_INCLUDE_DIR)
-endif()
-
 list(FIND BasisUniversal_FIND_COMPONENTS "Encoder" _index)
 if(${_index} GREATER -1)
     list(APPEND BasisUniversal_FIND_COMPONENTS "Transcoder")
@@ -119,96 +77,176 @@ endmacro()
 foreach(_component ${BasisUniversal_FIND_COMPONENTS})
     if(_component STREQUAL "Encoder")
         if(NOT TARGET BasisUniversal::Encoder)
-            find_path(BasisUniversalEncoder_DIR NAMES basisu_frontend.cpp
-                HINTS "${BASIS_UNIVERSAL_DIR}" "${BASIS_UNIVERSAL_DIR}/encoder"
-                NO_CMAKE_FIND_ROOT_PATH)
-            if(BasisUniversalEncoder_DIR)
-                set(BasisUniversal_Encoder_FOUND TRUE)
+            # Try to find compiled library when installed through vcpkg
+            find_library(BasisUniversalEncoder_LIBRARY_RELEASE basisu_encoder)
+            find_library(BasisUniversalEncoder_LIBRARY_DEBUG basisu_encoder HINTS "debug")
+
+            if(BasisUniversalEncoder_LIBRARY_DEBUG OR BasisUniversalEncoder_LIBRARY_RELEASE)
+                find_path(BasisUniversalEncoder_INCLUDE_DIR basisu_enc.h PATH_SUFFIXES "basisu/encoder")
+
+                add_library(BasisUniversal::Encoder UNKNOWN IMPORTED)
+                if(BasisUniversalEncoder_LIBRARY_DEBUG)
+                    set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                        IMPORTED_LOCATION_DEBUG ${BasisUniversalEncoder_LIBRARY_DEBUG})
+                endif()
+                if(BasisUniversalEncoder_LIBRARY_RELEASE)
+                    set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                        IMPORTED_LOCATION_RELEASE ${BasisUniversalEncoder_LIBRARY_RELEASE})
+                endif()
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_INCLUDE_DIRECTORIES ${BasisUniversalEncoder_INCLUDE_DIR})
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES BasisUniversal::Transcoder)
+
+                if((BasisUniversalEncoder_LIBRARY_DEBUG OR BasisUniversalEncoder_LIBRARY_RELEASE) AND BasisUniversalEncoder_INCLUDE_DIR)
+                    set(BasisUniversal_Encoder_FOUND TRUE)
+                endif()
+
+            # Fall back to finding sources and compile them with the target they are linked to
             else()
-                message(SEND_ERROR
-                    "Could not find encoder in basis_universal directory.\n"
-                    "Set BASIS_UNIVERSAL_DIR to the root of a directory containing basis_universal source.")
+                find_path(BasisUniversalEncoder_DIR NAMES basisu_frontend.cpp
+                    HINTS "${BASIS_UNIVERSAL_DIR}" "${BASIS_UNIVERSAL_DIR}/encoder"
+                    NO_CMAKE_FIND_ROOT_PATH)
+                if(BasisUniversalEncoder_DIR)
+                    set(BasisUniversal_Encoder_FOUND TRUE)
+                else()
+                    message(SEND_ERROR
+                        "Could not find encoder in basis_universal directory.\n"
+                        "Set BASIS_UNIVERSAL_DIR to the root of a directory containing basis_universal source.")
+                endif()
+
+                set(BasisUniversalEncoder_SOURCES
+                    ${BasisUniversalEncoder_DIR}/basisu_astc_decomp.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_backend.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_basis_file.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_comp.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_enc.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_etc.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_frontend.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_global_selector_palette_helpers.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_gpu_texture.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_pvrtc1_4.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_resampler.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_resample_filters.cpp
+                    ${BasisUniversalEncoder_DIR}/basisu_ssim.cpp
+                    ${BasisUniversalEncoder_DIR}/lodepng.cpp)
+
+                foreach(_file ${BasisUniversalEncoder_SOURCES})
+                    _basis_setup_source_file(${_file})
+                endforeach()
+
+                # Disable the find root path here, it overrides the
+                # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE setting potentially set in
+                # toolchains.
+                find_path(BasisUniversalEncoder_INCLUDE_DIR NAMES basisu_frontend.h HINTS
+                    HINTS "${BASIS_UNIVERSAL_DIR}" "${BASIS_UNIVERSAL_DIR}/encoder"
+                    NO_CMAKE_FIND_ROOT_PATH)
+                mark_as_advanced(BasisUniversalEncoder_INCLUDE_DIR)
+
+                add_library(BasisUniversal::Encoder INTERFACE IMPORTED)
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_INCLUDE_DIRECTORIES ${BasisUniversalEncoder_INCLUDE_DIR})
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_SOURCES "${BasisUniversalEncoder_SOURCES}")
+                # Explicitly *not* linking this to Threads::Threads because when
+                # done like that, std::thread creation will die on a null function
+                # pointer call (inside __gthread_create, which weakly links to
+                # pthread) in the BasisImageConverter UNLESS the final application
+                # is linked to pthread as well. As far as I tried (four hours
+                # lost), there's no way to check if the weak pthread_create pointer
+                # is null -- tried so far:
+                #  - dlsym(self, "pthread_create") returns non-null
+                #  - dlopen("libpthread.so") returns non-null
+                #  - defining a weakref pthread_create the same way as glibc does
+                #    https://github.com/gcc-mirror/gcc/blob/3e7b85061947bdc7c7465743ba90734566860821/libgcc/gthr-posix.h#L106
+                #    returns non-null
+                # The rest is documented in the BasisImageConverter plugin itself.
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_LINK_LIBRARIES BasisUniversal::Transcoder)
+                set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
+                    INTERFACE_COMPILE_DEFINITIONS "BASISU_NO_ITERATOR_DEBUG_LEVEL")
             endif()
-
-            set(BasisUniversalEncoder_SOURCES
-                ${BasisUniversalEncoder_DIR}/basisu_astc_decomp.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_backend.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_basis_file.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_comp.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_enc.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_etc.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_frontend.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_global_selector_palette_helpers.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_gpu_texture.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_pvrtc1_4.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_resampler.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_resample_filters.cpp
-                ${BasisUniversalEncoder_DIR}/basisu_ssim.cpp
-                ${BasisUniversalEncoder_DIR}/lodepng.cpp)
-
-            foreach(_file ${BasisUniversalEncoder_SOURCES})
-                _basis_setup_source_file(${_file})
-            endforeach()
-
-            add_library(BasisUniversal::Encoder INTERFACE IMPORTED)
-            set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
-                INTERFACE_INCLUDE_DIRECTORIES ${BasisUniversalEncoder_INCLUDE_DIR})
-            set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
-                INTERFACE_SOURCES "${BasisUniversalEncoder_SOURCES}")
-            # Explicitly *not* linking this to Threads::Threads because when
-            # done like that, std::thread creation will die on a null function
-            # pointer call (inside __gthread_create, which weakly links to
-            # pthread) in the BasisImageConverter UNLESS the final application
-            # is linked to pthread as well. As far as I tried (four hours
-            # lost), there's no way to check if the weak pthread_create pointer
-            # is null -- tried so far:
-            #  - dlsym(self, "pthread_create") returns non-null
-            #  - dlopen("libpthread.so") returns non-null
-            #  - defining a weakref pthread_create the same way as glibc does
-            #    https://github.com/gcc-mirror/gcc/blob/3e7b85061947bdc7c7465743ba90734566860821/libgcc/gthr-posix.h#L106
-            #    returns non-null
-            # The rest is documented in the BasisImageConverter plugin itself.
-            set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
-                INTERFACE_LINK_LIBRARIES BasisUniversal::Transcoder)
-            set_property(TARGET BasisUniversal::Encoder APPEND PROPERTY
-                INTERFACE_COMPILE_DEFINITIONS "BASISU_NO_ITERATOR_DEBUG_LEVEL")
         else()
             set(BasisUniversal_Encoder_FOUND TRUE)
         endif()
 
     elseif(_component STREQUAL "Transcoder")
         if(NOT TARGET BasisUniversal::Transcoder)
-            find_path(BasisUniversalTranscoder_DIR NAMES basisu_transcoder.cpp
-                HINTS "${BASIS_UNIVERSAL_DIR}/transcoder" "${BASIS_UNIVERSAL_DIR}"
-                NO_CMAKE_FIND_ROOT_PATH)
-            if(BasisUniversalTranscoder_DIR)
-                set(BasisUniversal_Transcoder_FOUND TRUE)
+            find_library(BasisUniversalTranscoder_LIBRARY_RELEASE basisu_transcoder)
+            find_library(BasisUniversalTranscoder_LIBRARY_DEBUG basisu_transcoder HINTS "debug")
+
+            if(BasisUniversalTranscoder_LIBRARY_DEBUG OR BasisUniversalTranscoder_LIBRARY_RELEASE)
+                # Encoder includes expect the basis includes to be prefixed with transcoder/ as in the
+                # original basis_universal repository.
+                find_path(BasisUniversalTranscoder_INCLUDE_DIR transcoder/basisu_transcoder.h PATH_SUFFIXES "basisu")
+
+                add_library(BasisUniversal::Transcoder UNKNOWN IMPORTED)
+                if(BasisUniversalTranscoder_LIBRARY_DEBUG)
+                    set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                        IMPORTED_LOCATION_DEBUG ${BasisUniversalTranscoder_LIBRARY_DEBUG})
+                endif()
+                if(BasisUniversalTranscoder_LIBRARY_RELEASE)
+                    set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                        IMPORTED_LOCATION_RELEASE ${BasisUniversalTranscoder_LIBRARY_RELEASE})
+                endif()
+                set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                    INTERFACE_INCLUDE_DIRECTORIES
+                    ${BasisUniversalTranscoder_INCLUDE_DIR}
+                    ${BasisUniversalTranscoder_INCLUDE_DIR}/transcoder)
+
+                if((BasisUniversalTranscoder_LIBRARY_DEBUG OR BasisUniversalTranscoder_LIBRARY_RELEASE) AND BasisUniversalTranscoder_INCLUDE_DIR)
+                    set(BasisUniversal_Transcoder_FOUND TRUE)
+                endif()
+
+            # Fall back to finding sources and compile them with the target they are linked to
             else()
-                message(SEND_ERROR
-                    "Could not find transcoder in basis_universal directory.\n"
-                    "Set BASIS_UNIVERSAL_DIR to the root of a directory containing basis_universal source.")
+
+                find_path(BasisUniversalTranscoder_DIR NAMES basisu_transcoder.cpp
+                    HINTS "${BASIS_UNIVERSAL_DIR}/transcoder" "${BASIS_UNIVERSAL_DIR}"
+                    NO_CMAKE_FIND_ROOT_PATH)
+                if(BasisUniversalTranscoder_DIR)
+                    set(BasisUniversal_Transcoder_FOUND TRUE)
+                else()
+                    message(SEND_ERROR
+                        "Could not find transcoder in basis_universal directory.\n"
+                        "Set BASIS_UNIVERSAL_DIR to the root of a directory containing basis_universal source.")
+                endif()
+                set(BasisUniversalTranscoder_SOURCES
+                    ${BasisUniversalTranscoder_DIR}/basisu_transcoder.cpp)
+
+                foreach(_file ${BasisUniversalTranscoder_SOURCES})
+                    _basis_setup_source_file(${_file})
+                endforeach()
+
+                # Disable the find root path here, it overrides the
+                # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE setting potentially set in
+                # toolchains.
+                find_path(BasisUniversalTranscoder_INCLUDE_DIR NAMES basisu_transcoder.h
+                    HINTS "${BASIS_UNIVERSAL_DIR}/transcoder" "${BASIS_UNIVERSAL_DIR}"
+                    NO_CMAKE_FIND_ROOT_PATH)
+                mark_as_advanced(BasisUniversalTranscoder_INCLUDE_DIR)
+
+                add_library(BasisUniversal::Transcoder INTERFACE IMPORTED)
+                set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                    INTERFACE_INCLUDE_DIRECTORIES ${BasisUniversalTranscoder_INCLUDE_DIR})
+                set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                    INTERFACE_COMPILE_DEFINITIONS "BASISU_NO_ITERATOR_DEBUG_LEVEL")
+                set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
+                    INTERFACE_SOURCES "${BasisUniversalTranscoder_SOURCES}")
             endif()
-            set(BasisUniversalTranscoder_SOURCES
-                ${BasisUniversalTranscoder_DIR}/basisu_transcoder.cpp)
-
-            foreach(_file ${BasisUniversalTranscoder_SOURCES})
-                _basis_setup_source_file(${_file})
-            endforeach()
-
-            add_library(BasisUniversal::Transcoder INTERFACE IMPORTED)
-            set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
-                INTERFACE_INCLUDE_DIRECTORIES ${BasisUniversalTranscoder_INCLUDE_DIR})
-            set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
-                INTERFACE_COMPILE_DEFINITIONS "BASISU_NO_ITERATOR_DEBUG_LEVEL")
-            set_property(TARGET BasisUniversal::Transcoder APPEND PROPERTY
-                INTERFACE_SOURCES "${BasisUniversalTranscoder_SOURCES}")
         else()
             set(BasisUniversal_Transcoder_FOUND TRUE)
         endif()
     endif()
 endforeach()
 
+if(BasisUniversalEncoder_INCLUDE_DIR)
+    set(_BASISUNIVERSAL_VARS BasisUniversalEncoder_INCLUDE_DIR)
+else()
+    set(_BASISUNIVERSAL_VARS BasisUniversalTranscoder_INCLUDE_DIR)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(BasisUniversal
-    REQUIRED_VARS BasisUniversalTranscoder_INCLUDE_DIR BasisUniversalEncoder_INCLUDE_DIR
+    REQUIRED_VARS ${_BASISUNIVERSAL_VARS}
     HANDLE_COMPONENTS)


### PR DESCRIPTION
Hi @mosra !

As promised, here's a version of the FindBasisUniversal that works with vcpkg.
I have a maybe unconventional use of `find_package_handle_standard_args` in there for setting the `BasisUniversal_(Encoder|Transcoder_FOUND` vars. It causes output when both are found and I'm interested in your judgment whether that is a good trade-off for the more concise code.

Best,
Jonathan