### PR TITLE
StbTrueTypeFont: Use fabsf instead of fabs

### DIFF
--- a/src/MagnumPlugins/StbTrueTypeFont/StbTrueTypeFont.cpp
+++ b/src/MagnumPlugins/StbTrueTypeFont/StbTrueTypeFont.cpp
@@ -35,6 +35,10 @@
 
 #define STB_TRUETYPE_IMPLEMENTATION
 #define STBTT_STATIC
+#include <math.h>
+/* Use fabsf instead of fabs (double version) for 30% performance
+   improvement on MSVC Debug builds */
+#define STBTT_fabs(x) fabsf(x)
 #include "stb_truetype.h"
 
 namespace Magnum { namespace Text {


### PR DESCRIPTION
Hey @mosra !

As discussed via gitter, the performance of StbTrueTypeFont on MSVC Debug builds is crazy bad. Through profiling I figured out that all of the time is spent in  `fabs()` during rasterization of the Glyphs in `fillGlyphCache`.
In embedded stbfreetype in ImGui this is not an issue for some reason, and I found that they override `STBTT_fabs(x)` with `fabsf(x)`, the `float` override of `fabs`.
This didn't entirely fix the issue (imgui is still over 10x faster at loading a font), but at least 30% speedup.

I tried to figure out if there are different compile flags applied during compilation of imgui, but that doesn't seem to be the case.

Best, 
Jonathan.