### PR TITLE
Material texture layer support for TinyGltfImporter and AssimpImporter

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.conf
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.conf
@@ -29,6 +29,11 @@ provides=XglImporter
 # AI_CONFIG_* values, can be changed only before the first file is opened
 ImportColladaIgnoreUpDirection=false
 
+# Allow non-default texture coordinate sets. If disabled, materials with
+# non-zero texture coordinate sets (which need explicit support in shaders)
+# will fail to import.
+allowMaterialTextureCoordinateSets=false
+
 # aiPostProcessSteps, applied to each opened file
 [configuration/postprocess]
 JoinIdenticalVertices=true

--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.h
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.h
@@ -213,6 +213,9 @@ verbosity levels in each instance.
     @cpp 0xffffff_srgbf @ce, which causes all other color information to be
     discarded. If such a case is detected, the ambient is forced back to
     @cpp 0x000000_srgbf @ce. See also [assimp/assimp#2059](https://github.com/assimp/assimp/issues/2059).
+-   Unless explicitly enabled with the @cb{.ini} allowMaterialTextureCoordinateSets @ce
+    @ref Trade-AssimpImporter-configuration "configuration option", only the
+    first set of texture coordinates is supported.
 
 @subsection Trade-AssimpImporter-limitations-lights Light import
 

--- a/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
+++ b/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
@@ -75,6 +75,7 @@ corrade_add_test(AssimpImporterTest AssimpImporterTest.cpp
         material-texture.dae
         material-color-texture.mtl
         material-color-texture.obj
+        material-coordinate-sets.dae
         mesh.dae
         mips.dds
         multiple-textures.mtl r.png g.png b.png y.png

--- a/src/MagnumPlugins/AssimpImporter/Test/material-coordinate-sets.dae
+++ b/src/MagnumPlugins/AssimpImporter/Test/material-coordinate-sets.dae
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <library_images>
+    <image id="diffusenormal_texture" name="diffusenormal_texture">
+      <init_from>diffuse_texture.png</init_from>
+    </image>
+    <image id="ambientspecular_texture" name="ambientspecular_texture">
+      <init_from>y.png</init_from>
+    </image>
+  </library_images>
+  <library_effects>
+    <effect id="Material-effect">
+      <profile_COMMON>
+        <newparam sid="ambientspecular_texture-surface">
+          <surface type="2D">
+            <init_from>ambientspecular_texture</init_from>
+          </surface>
+        </newparam>
+        <newparam sid="diffusenormal_texture-surface">
+          <surface type="2D">
+            <init_from>diffusenormal_texture</init_from>
+          </surface>
+        </newparam>
+        <newparam sid="ambientspecular_texture-sampler">
+          <sampler2D>
+            <source>ambientspecular_texture-surface</source>
+          </sampler2D>
+        </newparam>
+        <newparam sid="diffusenormal_texture-sampler">
+          <sampler2D>
+            <source>diffusenormal_texture-surface</source>
+          </sampler2D>
+        </newparam>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <texture texture="ambientspecular_texture-sampler" texcoord="uv1"/>
+            </ambient>
+            <diffuse>
+              <texture texture="diffusenormal_texture-sampler" texcoord="uv2"/>
+            </diffuse>
+            <specular>
+              <texture texture="ambientspecular_texture-sampler" texcoord="uv3"/>
+            </specular>
+            <shininess>
+              <float sid="shininess">50</float>
+            </shininess>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+          <extra>
+            <technique profile="FCOLLADA">
+              <bump bumptype="NORMALMAP">
+                <texture texture="diffusenormal_texture-sampler" texcoord="uv2"/>
+              </bump>
+            </technique>
+          </extra>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material-material" name="Material">
+      <instance_effect url="#Material-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube-mesh" name="Cube">
+      <mesh>
+        <source id="Cube-mesh-positions">
+          <float_array id="Cube-mesh-positions-array" count="9">-1 -1 1 -1 1 1 1 -1 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-positions-array" count="3" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-normals">
+          <float_array id="Cube-mesh-normals-array" count="3">0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-normals-array" count="1" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-uvs">
+          <float_array id="Cube-mesh-uvs-array" count="2">1 0</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-uvs-array" count="1" stride="2">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-uvs1">
+          <float_array id="Cube-mesh-uvs1-array" count="2">1 0.4</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-uvs1-array" count="1" stride="2">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube-mesh-vertices">
+          <input semantic="POSITION" source="#Cube-mesh-positions"/>
+        </vertices>
+        <polylist material="Material-material" count="1">
+          <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#Cube-mesh-uvs" offset="1" set="0"/>
+          <input semantic="TEXCOORD" source="#Cube-mesh-uvs1" offset="1" set="1"/>
+          <input semantic="TEXCOORD" source="#Cube-mesh-uvs" offset="1" set="2"/>
+          <input semantic="TEXCOORD" source="#Cube-mesh-uvs" offset="1" set="3"/>
+          <vcount>3</vcount>
+          <p>1 0 0 0 2 0</p>
+        </polylist>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Cube" name="Cube" type="NODE">
+        <matrix sid="transform">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>
+        <instance_geometry url="#Cube-mesh" name="Cube">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material-material" target="#Material-material">
+                  <bind_vertex_input semantic="uv0" input_semantic="TEXCOORD" input_set="0"/>
+                  <bind_vertex_input semantic="uv1" input_semantic="TEXCOORD" input_set="1"/>
+                  <bind_vertex_input semantic="uv2" input_semantic="TEXCOORD" input_set="2"/>
+                  <bind_vertex_input semantic="uv3" input_semantic="TEXCOORD" input_set="3"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>

--- a/src/MagnumPlugins/TinyGltfImporter/Test/CMakeLists.txt
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/CMakeLists.txt
@@ -100,6 +100,7 @@ corrade_add_test(TinyGltfImporterTest
         material-texcoord-flip.bin
         material-texcoord-flip.gltf
         material-texcoord-flip-unnormalized.gltf
+        material-texcoord-sets.gltf
         mesh.gltf
         mesh.bin
         mesh.glb

--- a/src/MagnumPlugins/TinyGltfImporter/Test/material-invalid.gltf
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/material-invalid.gltf
@@ -16,25 +16,9 @@
             }
         },
         {
-            "name": "invalid texCoord index pbrMetallicRoughness",
-            "pbrMetallicRoughness": {
-                "baseColorTexture": {
-                    "index": 1,
-                    "texCoord": 1
-                }
-            }
-        },
-        {
             "name": "invalid texture index normalTexture",
             "normalTexture": {
                 "index": 2
-            }
-        },
-        {
-            "name": "invalid texCoord index normalTexture",
-            "normalTexture": {
-                "index": 1,
-                "texCoord": 1
             }
         },
         {
@@ -48,33 +32,11 @@
             }
         },
         {
-            "name": "invalid texCoord index pbrSpecularGlossiness diffuse",
-            "extensions": {
-                "KHR_materials_pbrSpecularGlossiness": {
-                    "diffuseTexture": {
-                        "index": 1,
-                        "texCoord": 1
-                    }
-                }
-            }
-        },
-        {
             "name": "invalid texture index pbrSpecularGlossiness specular",
             "extensions": {
                 "KHR_materials_pbrSpecularGlossiness": {
                     "specularGlossinessTexture": {
                         "index": 2
-                    }
-                }
-            }
-        },
-        {
-            "name": "invalid texCoord index pbrSpecularGlossiness specular",
-            "extensions": {
-                "KHR_materials_pbrSpecularGlossiness": {
-                    "specularGlossinessTexture": {
-                        "index": 1,
-                        "texCoord": 1
                     }
                 }
             }

--- a/src/MagnumPlugins/TinyGltfImporter/Test/material-texcoord-sets.gltf
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/material-texcoord-sets.gltf
@@ -1,0 +1,48 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "materials": [
+        {
+            "name": "texCoord index pbrMetallicRoughness",
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {
+                    "index": 1,
+                    "texCoord": 1
+                }
+            }
+        },
+        {
+            "name": "texCoord index normalTexture",
+            "normalTexture": {
+                "index": 1,
+                "texCoord": 2
+            }
+        },
+        {
+            "name": "texCoord index pbrSpecularGlossiness diffuse",
+            "extensions": {
+                "KHR_materials_pbrSpecularGlossiness": {
+                    "diffuseTexture": {
+                        "index": 1,
+                        "texCoord": 3
+                    }
+                }
+            }
+        },
+        {
+            "name": "texCoord index pbrSpecularGlossiness specular",
+            "extensions": {
+                "KHR_materials_pbrSpecularGlossiness": {
+                    "specularGlossinessTexture": {
+                        "index": 1,
+                        "texCoord": 4
+                    }
+                }
+            }
+        }
+    ],
+    "textures": [
+        {}, {}
+    ]
+}

--- a/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.conf
+++ b/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.conf
@@ -34,4 +34,9 @@ textureCoordinateYFlipInMaterial=false
 # The non-standard MeshAttribute::ObjectId is by default recognized under this
 # name. Change if your file uses a different identifier.
 objectIdAttribute=_OBJECT_ID
+
+# Allow non-default texture coordinate sets. If disabled, materials with
+# non-zero texture coordinate sets (which need explicit support in shaders)
+# will fail to import.
+allowMaterialTextureCoordinateSets=false
 # [config]

--- a/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.h
+++ b/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.h
@@ -269,7 +269,9 @@ fail.
 -   Subset of all material specs is currently imported as @ref PhongMaterialData,
     including normal textures
 -   Ambient color is always @cpp 0x000000_rgbf @ce (never a texture)
--   Only the first set of texture coordinates is supported
+-   Unless explicitly enabled with the @cb{.ini} allowMaterialTextureCoordinateSets @ce
+    @ref Trade-TinyGltfImporter-configuration "configuration option", only the
+    first set of texture coordinates is supported.
 -   If [KHR_texture_transform](https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_texture_transform/README.md)
     is present, the imported material has @ref PhongMaterialData::Flag::TextureTransformation
     set. All textures have to share the same transformation and the
@@ -482,7 +484,7 @@ class MAGNUM_TINYGLTFIMPORTER_EXPORT TinyGltfImporter: public AbstractImporter {
         MAGNUM_TINYGLTFIMPORTER_LOCAL MeshAttribute doMeshAttributeForName(const std::string& name) override;
         MAGNUM_TINYGLTFIMPORTER_LOCAL std::string doMeshAttributeName(UnsignedShort name) override;
 
-        MAGNUM_TINYGLTFIMPORTER_LOCAL bool materialTexture(const char* name, Int texture, Int texCoord, const tinygltf::Value& extensions, UnsignedInt& index, Containers::Optional<Matrix3>& textureMatrix, PhongMaterialData::Flags& flags) const;
+        MAGNUM_TINYGLTFIMPORTER_LOCAL bool materialTexture(const char* name, Int texture, Int texCoord, const tinygltf::Value& extensions, UnsignedInt& index, UnsignedInt& coordinateSet, Containers::Optional<Matrix3>& textureMatrix, PhongMaterialData::Flags& flags) const;
 
         MAGNUM_TINYGLTFIMPORTER_LOCAL UnsignedInt doMaterialCount() const override;
         MAGNUM_TINYGLTFIMPORTER_LOCAL Int doMaterialForName(const std::string& name) override;


### PR DESCRIPTION
Hi @mosra !

Here's the accompanying PR for mosra/magnum#438. 

**TODOs:**

 - [x] Compile check
 - [x] Add configuration value for textures sets
 - [x] Testing (A gltf+glb file with a different layer for each, reusing that for assimp, too)
 - [x] Advertise support