### PR TITLE
TinyGltfImporter: Import Weights and JointIds mesh attributes

### DIFF
--- a/src/MagnumPlugins/TinyGltfImporter/Test/TinyGltfImporterTest.cpp
+++ b/src/MagnumPlugins/TinyGltfImporter/Test/TinyGltfImporterTest.cpp
@@ -101,6 +101,8 @@ struct TinyGltfImporterTest: TestSuite::Tester {
     void meshIndexed();
     void meshIndexedAttributeless();
     void meshColors();
+    void meshJointIds();
+    void meshWeights();
     void meshCustomAttributes();
     void meshCustomAttributesNoFileOpened();
     void meshMultiplePrimitives();
@@ -474,6 +476,8 @@ TinyGltfImporterTest::TinyGltfImporterTest() {
               &TinyGltfImporterTest::meshIndexed,
               &TinyGltfImporterTest::meshIndexedAttributeless,
               &TinyGltfImporterTest::meshColors,
+              &TinyGltfImporterTest::meshJointIds,
+              &TinyGltfImporterTest::meshWeights,
               &TinyGltfImporterTest::meshCustomAttributes,
               &TinyGltfImporterTest::meshCustomAttributesNoFileOpened,
               &TinyGltfImporterTest::meshMultiplePrimitives});
@@ -1655,6 +1659,42 @@ void TinyGltfImporterTest::meshColors() {
     Containers::Pointer<AbstractImporter> importer = _manager.instantiate("TinyGltfImporter");
     CORRADE_VERIFY(importer->openFile(Utility::Directory::join(TINYGLTFIMPORTER_TEST_DIR,
         "mesh-colors.gltf")));
+
+    CORRADE_COMPARE(importer->meshCount(), 1);
+
+    auto mesh = importer->mesh(0);
+    CORRADE_VERIFY(mesh);
+    CORRADE_VERIFY(!mesh->isIndexed());
+
+    CORRADE_COMPARE(mesh->attributeCount(), 3);
+    CORRADE_COMPARE(mesh->attributeFormat(MeshAttribute::Position), VertexFormat::Vector3);
+    CORRADE_COMPARE_AS(mesh->attribute<Vector3>(MeshAttribute::Position),
+        Containers::arrayView<Vector3>({
+            {1.5f, -1.0f, -0.5f},
+            {-0.5f, 2.5f, 0.75f},
+            {-2.0f, 1.0f, 0.3f}
+        }), TestSuite::Compare::Container);
+    CORRADE_COMPARE(mesh->attributeCount(MeshAttribute::Color), 2);
+    CORRADE_COMPARE(mesh->attributeFormat(MeshAttribute::Color, 0), VertexFormat::Vector3);
+    CORRADE_COMPARE_AS(mesh->attribute<Vector3>(MeshAttribute::Color),
+        Containers::arrayView<Vector3>({
+            {0.1f, 0.2f, 0.3f},
+            {0.4f, 0.5f, 0.6f},
+            {0.7f, 0.8f, 0.9f}
+        }), TestSuite::Compare::Container);
+    CORRADE_COMPARE(mesh->attributeFormat(MeshAttribute::Color, 1), VertexFormat::Vector4);
+    CORRADE_COMPARE_AS(mesh->attribute<Vector4>(MeshAttribute::Color, 1),
+        Containers::arrayView<Vector4>({
+            {0.1f, 0.2f, 0.3f, 0.4f},
+            {0.5f, 0.6f, 0.7f, 0.8f},
+            {0.9f, 1.0f, 1.1f, 1.2f}
+        }), TestSuite::Compare::Container);
+}
+
+void TinyGltfImporterTest::meshJointIds() {
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("TinyGltfImporter");
+    CORRADE_VERIFY(importer->openFile(Utility::Directory::join(TINYGLTFIMPORTER_TEST_DIR,
+        "mesh-jointIds.gltf")));
 
     CORRADE_COMPARE(importer->meshCount(), 1);
 

--- a/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.cpp
+++ b/src/MagnumPlugins/TinyGltfImporter/TinyGltfImporter.cpp
@@ -1171,6 +1171,41 @@ Containers::Optional<MeshData> TinyGltfImporter::doMesh(const UnsignedInt id, Un
                 return Containers::NullOpt;
             }
 
+        /* Joint attribute ends with _0, _1 ... */
+        } else if(Utility::String::beginsWith(attribute.first, "JOINTS")) {
+            name = MeshAttribute::JointIds;
+
+            if(accessor.type != TINYGLTF_TYPE_VEC4) {
+                Error{} << "Trade::TinyGltfImporter::mesh(): unexpected JOINTS type" << accessor.type;
+                return Containers::NullOpt;
+            }
+
+            if(!(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE) &&
+               !(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT)) {
+                Error{} << "Trade::TinyGltfImporter::mesh(): unsupported JOINTS component type"
+                    << (accessor.normalized ? "normalized" : "unnormalized")
+                    << accessor.componentType;
+                return Containers::NullOpt;
+            }
+
+        /* Weights attribute ends with _0, _1 ... */
+        } else if(Utility::String::beginsWith(attribute.first, "WEIGHTS")) {
+            name = MeshAttribute::Weights;
+
+            if(accessor.type != TINYGLTF_TYPE_VEC4) {
+                Error{} << "Trade::TinyGltfImporter::mesh(): unexpected WEIGHTS type" << accessor.type;
+                return Containers::NullOpt;
+            }
+
+            if(!(accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT && !accessor.normalized) &&
+               !(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE && accessor.normalized) &&
+               !(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT && accessor.normalized)) {
+                Error{} << "Trade::TinyGltfImporter::mesh(): unsupported WEIGHTS component type"
+                    << (accessor.normalized ? "normalized" : "unnormalized")
+                    << accessor.componentType;
+                return Containers::NullOpt;
+            }
+
         /* Custom or unrecognized attributes, map to an ID */
         } else name = _d->meshAttributesForName.at(attribute.first);
 


### PR DESCRIPTION
Hi @mosra !

Building on top of https://github.com/mosra/magnum/pull/441, here's the import of the new mesh attributes in TinyGltfImporter.

Best,
Jonathan

**TODO**
 - [ ] Docs: Advertise support
 - [ ] Tests
 - [ ] What are `"skins"`? 
 - [ ] Is this sufficient to import skinned mesh animations?