### PR TITLE
AssimpImporter: support PBR and custom attribs.

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.conf
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.conf
@@ -29,6 +29,16 @@ provides=XglImporter
 # AI_CONFIG_* values, can be changed only before the first file is opened
 ImportColladaIgnoreUpDirection=false
 
+# Don't attempt recognizing builtin material attributes and import them as-is
+# with Assimp's internal names (so e.g. instead of DiffuseColor you'll get
+# $clr.diffuse). Mainly for testing purposes.
+rawMaterialData=false
+
+# Provide basic Phong material attributes even for PBR materials in order to be
+# compatible with PhongMaterialData workflows from version 2020.06 and before.
+# This option will eventually become disabled by default.
+phongMaterialFallback=true
+
 # aiPostProcessSteps, applied to each opened file
 [configuration/postprocess]
 JoinIdenticalVertices=true


### PR DESCRIPTION
Postponed from mosra/magnum#459. List of nightmares to wake up from:

- [ ] COLLADA ambient texture gets imported as LIGHTMAP (but ambient color is ambient color), however glTF occlusion texture gets imported as LIGHTMAP as well, what the heck do I do here? Why isn't glTF occlusion texture imported as AMBIENT_OCCLUSION if there's such a type ffs?!
- [x] import glTF PBR properties
- [ ] import other PBR properties (like, there's DIFFUSE_ROUGHNESS etc, what to do with that? which format uses it?)
- [ ] glTF `BaseColor` gets imported as `Diffuse`, detect that (using other attribs?) and fix
- [ ] glTF metallic/roughness gets imported as `UNKNOWN`, detect that (using other attribs?) and fix
- [ ] glTF `*TextureCoordinates` get imported as something else entirely for no reason, why?!
- [ ] glTF specular/glossiness texture gets imported as just `Specular`, with glossiness ignored, detect that and fix
- [ ] glTF files have one extra layer with the diffuse texture duplicated, why the fuck?! mention that in the docs at least
- [ ] what's that `$mat.gltf.pbrSpecularGlossiness` thing?
- [ ] detect presence of glTF metallic/roughness and specular/glossiness attributes and set `MaterialType` accordingly (or are those present always for any glTF files? ffs)
- [ ] disable the PBR enums and codepaths on older versions of Assimp somehow so we can still compile on Travis
- [ ] test the new code paths
  - [ ] glTF import will probably crash on all except the very latest versions, skip those there
- [x] importing unknown attributes as custom
  - [x] an ability to import all, not just unknown, attributes as "raw" without trying to make sense of those
  - [ ] test those code paths 

Current output from `magnum-sceneconverter` for an overview of *how bad* things are:

```
$ magnum-sceneconverter --info WaterBottle.gltf 
Material 0 (referenced by 1 objects): BottleMat
  $mat.gltf.pbrSpecularGlossiness @ Trade::MaterialAttributeType::String: 
  $mat.twosided @ Trade::MaterialAttributeType::String: 
  $tex.file.LIGHTMAP @ Trade::MaterialAttributeType::String: WaterBottle_occlusion.png
  $tex.file.UNKNOWN @ Trade::MaterialAttributeType::String: !WaterBottle_roughnessMetallic.png
  $tex.file.texCoord.DIFFUSE @ Trade::MaterialAttributeType::String: 
  $tex.file.texCoord.EMISSIVE @ Trade::MaterialAttributeType::String: 
  $tex.file.texCoord.LIGHTMAP @ Trade::MaterialAttributeType::String: 
  $tex.file.texCoord.NORMALS @ Trade::MaterialAttributeType::String: 
  $tex.file.texCoord.SPECULAR @ Trade::MaterialAttributeType::String: 
  $tex.file.texCoord.UNKNOWN @ Trade::MaterialAttributeType::String: 
  $tex.strength.LIGHTMAP @ Trade::MaterialAttributeType::Float: 1
  AlphaBlend @ Trade::MaterialAttributeType::Bool: false
  AlphaMask @ Trade::MaterialAttributeType::Float: 0.5
  BaseColor @ Trade::MaterialAttributeType::Vector4: Vector(1, 1, 1, 1)
  DiffuseColor @ Trade::MaterialAttributeType::Vector4: Vector(1, 1, 1, 1)
  DiffuseTexture @ Trade::MaterialAttributeType::UnsignedInt: 0
  EmissiveColor @ Trade::MaterialAttributeType::Vector3: Vector(1, 1, 1)
  EmissiveTexture @ Trade::MaterialAttributeType::UnsignedInt: 5
  Glossiness @ Trade::MaterialAttributeType::Float: 1
  Metalness @ Trade::MaterialAttributeType::Float: 1
  NormalTexture @ Trade::MaterialAttributeType::UnsignedInt: 3
  NormalTextureScale @ Trade::MaterialAttributeType::Float: 1
  Roughness @ Trade::MaterialAttributeType::Float: 1
  Shininess @ Trade::MaterialAttributeType::Float: 1000
  SpecularColor @ Trade::MaterialAttributeType::Vector4: Vector(1, 1, 1, 1)
  SpecularTexture @ Trade::MaterialAttributeType::UnsignedInt: 6
  Layer 1:
    $tex.file.texCoord.DIFFUSE @ Trade::MaterialAttributeType::String: 
    DiffuseTexture @ Trade::MaterialAttributeType::UnsignedInt: 1
```