### PR TITLE
[StanfordImporter] Support vertex_index for face list

### DIFF
--- a/src/MagnumPlugins/StanfordImporter/StanfordImporter.cpp
+++ b/src/MagnumPlugins/StanfordImporter/StanfordImporter.cpp
@@ -378,7 +378,7 @@ void StanfordImporter::openDataInternal(Containers::Array<char>&& data) {
                 /* Face element properties */
                 } else if(propertyType == PropertyType::Face) {
                     /* Face vertex indices */
-                    if(tokens.size() == 5 && tokens[1] == "list" && tokens[4] == "vertex_indices") {
+                    if(tokens.size() == 5 && tokens[1] == "list" && (tokens[4] == "vertex_indices" || tokens[4] == "vertex_index")) {
                         state->faceIndicesOffset = state->faceSkip;
                         state->faceSkip = 0;
 


### PR DESCRIPTION
Assimp (at least) exports ply files with faces as `property list uchar int vertex_index` whereas the code here supports only `vertex_indices` as a name (assimp parses both).  The ostensible [PLY reference](http://paulbourke.net/dataformats/ply/) seems to conflate them, implying to me it was silently changed at some point.  This change adds support for both.