### PR TITLE
BasisImporter: Initialize state and default configuration for direct use

### DIFF
--- a/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
@@ -138,7 +138,11 @@ void BasisImporter::initialize() {
     basist::basisu_transcoder_init();
 }
 
-BasisImporter::BasisImporter() = default;
+BasisImporter::BasisImporter(): _state{Containers::InPlaceInit} {
+    /* Initialize default configuration values */
+    /** @todo horrible workaround, fix this properly */
+    configuration().setValue("format", "");
+}
 
 BasisImporter::BasisImporter(PluginManager::AbstractManager& manager, const std::string& plugin): AbstractImporter{manager, plugin} {
     /* Initializes codebook */


### PR DESCRIPTION
@mosra As discussed via gitter!

The `BasisImporter` default constructor was not initializing its state, preventing direct use through

```cpp
BasisImporter::initialize();
BasisImporter importer;
```

Best,
Jonathan