### PR TITLE
AssimpImporter: normalize image paths

### DIFF
--- a/doc/changelog-plugins.dox
+++ b/doc/changelog-plugins.dox
@@ -87,6 +87,8 @@ namespace Magnum {
 -   @ref Audio::DrFlacImporter "DrFlacAudioImporter" no longer advertises
     support for 32-bit-per-channel FLAC files, as there's no known way to
     produce them and thus the case is impossible to test for.
+-   @ref Trade::AssimpImporter "AssimpImporter" now imports files with
+    non-normalized external image paths also on non-Windows platforms
 
 @subsection changelog-plugins-latest-buildsystem Build system
 

--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
@@ -3,7 +3,7 @@
 
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
                 2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
-    Copyright © 2017, 2020 Jonathan Hale <squareys@googlemail.com>
+    Copyright © 2017, 2020, 2021 Jonathan Hale <squareys@googlemail.com>
     Copyright © 2018 Konstantinos Chatzilygeroudis <costashatz@gmail.com>
     Copyright © 2019, 2020 Max Schwarz <max.schwarz@ais.uni-bonn.de>
     Copyright © 2021 Pablo Escobar <mail@rvrs.in>
@@ -1369,6 +1369,8 @@ AbstractImporter* AssimpImporter::setupOrReuseImporterForImage(const UnsignedInt
 
         AnyImageImporter importer{*manager()};
         if(fileCallback()) importer.setFileCallback(fileCallback(), fileCallbackUserData());
+        /* Assimp loads image path references as-is. It might contain windows path separators if the exporter didn't normalize */
+        std::replace(path.begin(), path.end(), '\\', '/');
         /* Assimp doesn't trim spaces from the end of image paths in OBJ
            materials so we have to. See the image-filename-space.mtl test. */
         if(!importer.openFile(Utility::String::trim(Utility::Directory::join(_f->filePath ? *_f->filePath : "", path))))

--- a/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
+++ b/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
@@ -302,6 +302,10 @@ AssimpImporterTest::AssimpImporterTest() {
     #ifdef STBIMAGEIMPORTER_PLUGIN_FILENAME
     CORRADE_INTERNAL_ASSERT_OUTPUT(_manager.load(STBIMAGEIMPORTER_PLUGIN_FILENAME) & PluginManager::LoadState::Loaded);
     #endif
+    /* The PngImporter (for PNG image loading) is optional */
+    #ifdef PNGIMPORTER_PLUGIN_FILENAME
+    CORRADE_INTERNAL_ASSERT_OUTPUT(_manager.load(PNGIMPORTER_PLUGIN_FILENAME) & PluginManager::LoadState::Loaded);
+    #endif
 }
 
 void AssimpImporterTest::openFile() {

--- a/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
+++ b/src/MagnumPlugins/AssimpImporter/Test/AssimpImporterTest.cpp
@@ -2749,11 +2749,6 @@ void AssimpImporterTest::imagePathNonNormalized() {
 
     CORRADE_COMPARE(importer->image2DCount(), 1);
     Containers::Optional<ImageData2D> image = importer->image2D(0);
-#ifndef CORRADE_TARGET_WINDOWS
-    CORRADE_EXPECT_FAIL("Assimp does not normalize filepaths on non-Windows systems");
-    CORRADE_VERIFY(image);
-    return;
-#endif
     CORRADE_VERIFY(image);
     CORRADE_COMPARE(image->size(), Vector2i{1});
     constexpr char pixels[] = { '\xb3', '\x69', '\x00', '\xff' };

--- a/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
+++ b/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
@@ -73,6 +73,8 @@ corrade_add_test(AssimpImporterTest AssimpImporterTest.cpp
         exported-animation.gltf
         image-filename-trailing-space.mtl
         image-filename-trailing-space.obj
+        image-filename-backslash.mtl
+        image-filename-backslash.obj
         image-mips.mtl
         image-mips.obj
         light.dae

--- a/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
+++ b/src/MagnumPlugins/AssimpImporter/Test/CMakeLists.txt
@@ -4,6 +4,7 @@
 #   Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
 #               2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
 #   Copyright © 2021 Pablo Escobar <mail@rvrs.in>
+#   Copyright © 2021 Jonathan Hale <squareys@googlemail.com>
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a
 #   copy of this software and associated documentation files (the "Software"),
@@ -43,6 +44,9 @@ if(NOT MAGNUM_ASSIMPIMPORTER_BUILD_STATIC)
     endif()
     if(WITH_STBIMAGEIMPORTER)
         set(STBIMAGEIMPORTER_PLUGIN_FILENAME $<TARGET_FILE:StbImageImporter>)
+    endif()
+    if(WITH_PNGIMPORTER)
+        set(PNGIMPORTER_PLUGIN_FILENAME $<TARGET_FILE:PngImporter>)
     endif()
 endif()
 

--- a/src/MagnumPlugins/AssimpImporter/Test/configure.h.cmake
+++ b/src/MagnumPlugins/AssimpImporter/Test/configure.h.cmake
@@ -4,6 +4,7 @@
     Copyright © 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019,
                 2020, 2021 Vladimír Vondruš <mosra@centrum.cz>
     Copyright © 2021 Pablo Escobar <mail@rvrs.in>
+    Copyright © 2021 Jonathan Hale <squareys@googlemail.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -27,5 +28,6 @@
 #cmakedefine ASSIMPIMPORTER_PLUGIN_FILENAME "${ASSIMPIMPORTER_PLUGIN_FILENAME}"
 #cmakedefine DDSIMPORTER_PLUGIN_FILENAME "${DDSIMPORTER_PLUGIN_FILENAME}"
 #cmakedefine STBIMAGEIMPORTER_PLUGIN_FILENAME "${STBIMAGEIMPORTER_PLUGIN_FILENAME}"
+#cmakedefine PNGIMPORTER_PLUGIN_FILENAME "${PNGIMPORTER_PLUGIN_FILENAME}"
 #define TINYGLTFIMPORTER_TEST_DIR "${TINYGLTFIMPORTER_TEST_DIR}"
 #define ASSIMPIMPORTER_TEST_DIR "${ASSIMPIMPORTER_TEST_DIR}"

--- a/src/MagnumPlugins/AssimpImporter/Test/image-filename-backslash.mtl
+++ b/src/MagnumPlugins/AssimpImporter/Test/image-filename-backslash.mtl
@@ -1,0 +1,12 @@
+newmtl Material
+Ns 96.078431
+Ka 1.0 1.0 1.0
+Kd 0.64 0.64 0.64
+Ks 0.5 0.5 0.5
+Ke 0.0 0.0 0.0
+Ni 1.0
+d 1.0
+illum 2
+map_Kd ..\Test\diffuse_texture.png
+
+# kate: hl Wavefront OBJ

--- a/src/MagnumPlugins/AssimpImporter/Test/image-filename-backslash.obj
+++ b/src/MagnumPlugins/AssimpImporter/Test/image-filename-backslash.obj
@@ -1,0 +1,10 @@
+mtllib image-filename-non-normalized.mtl
+o Cube
+v 1.0 0.0 -1.0
+v 1.0 0.0 1.0
+v -1.0 0.0 1.0
+v -1.0 0.0 -1.0
+vn 0.0 -1.0 0.0
+usemtl Material
+s off
+f 1//1 2//1 3//1 4//1


### PR DESCRIPTION
Hi @mosra !

As described in #101, I have an FBX file "from the wild", which has a relative windows path reference. This currently fails to load on Unix, but works on Windows.

[The first commit](6157ecb2db32663d8675e5bd3e7fe47d7c3485fe) runs the tests fine. My compiler complained that the symbol in StbImageImporter.cpp#99 does not exist, and since that made no sense whatsoever, I didn't want to waste time on that and I added support for PngImporter (it's might be faster, even).

[The second commit](97a7b34e6d58417859ae59b7e7b180ed7ac0b026) adds the test first with EXPECT_FAIL on non-Windows. This is to ensure that the CI would have indeed failed to import the image file.

The final commit fixes the test and removes the EXPECT_FAIL.

Best,
Jonathan