### PR TITLE
on Buster plugins should depend on libopenexr23

### DIFF
--- a/package/debian/control
+++ b/package/debian/control
@@ -17,5 +17,5 @@ Description: Plugins for the Magnum C++11/C++14 graphics engine
 Package: magnum-plugins
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, magnum, libdevil1c2, libjpeg8|libjpeg62-turbo, libpng16-16, libfaad2, libfreetype6, libassimp3v5|libassimp4|libassimp5, libopenexr22|libopenexr24
+Depends: ${shlibs:Depends}, ${misc:Depends}, magnum, libdevil1c2, libjpeg8|libjpeg62-turbo, libpng16-16, libfaad2, libfreetype6, libassimp3v5|libassimp4|libassimp5, libopenexr22|libopenexr23|libopenexr24
 Description: Plugins for the Magnum C++11/C++14 graphics engine


### PR DESCRIPTION
$ uname -a
Linux 4.19.0-17-amd64 #1 SMP Debian 4.19.194-3 (2021-07-18) x86_64 GNU/Linux

$ sudo apt install libopenexr22 libopenexr24
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package libopenexr22 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source
However the following packages replace it:
  libopenexr23

Package libopenexr24 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source

E: Package 'libopenexr22' has no installation candidate
E: Package 'libopenexr24' has no installation candidate