### PR TITLE
BasisImageConverter: support for 2D array images

### DIFF
--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
@@ -80,9 +80,12 @@ Containers::Array<char> convertLevelsToData(Containers::ArrayView<const BasicIma
     /** @todo Handle different image types (cube/array/volume) once this can be
         queried from images */
     Math::Vector<dimensions, Int> mipMask{1};
-    if(dimensions < 3) {
+    if(dimensions == 1) {
         /* Basis doesn't support 1D images, we treat them as 2D images with
            height 1 */
+        Warning{} << "Trade::BasisImageConverter::convertToData(): exporting 1D image as a 2D image with height 1";
+        params.m_tex_type = basist::basis_texture_type::cBASISTexType2D;
+    } else if(dimensions == 2) {
         params.m_tex_type = basist::basis_texture_type::cBASISTexType2D;
     } else {
         /* Encoding 3D images as KTX2 always produces 2D array images and mip

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
@@ -50,21 +50,10 @@ namespace Magnum { namespace Trade {
 
 using namespace Containers::Literals;
 
-BasisImageConverter::BasisImageConverter(Format format): _format{format} {
-    /* Passing an invalid Format enum is user error, we'll assert on that in
-       the convertToData() function */
-}
+namespace {
 
-BasisImageConverter::BasisImageConverter(PluginManager::AbstractManager& manager, const std::string& plugin): AbstractImageConverter{manager, plugin} {
-    if(plugin == "BasisKtxImageConverter")
-        _format = Format::Ktx;
-    else
-        _format = {}; /* Overridable by openFile() */
-}
-
-ImageConverterFeatures BasisImageConverter::doFeatures() const { return ImageConverterFeature::ConvertLevels2DToData; }
-
-Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) {
+template<UnsignedInt dimensions>
+Containers::Array<char> convertLevelsToData(Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Utility::ConfigurationGroup& configuration, ImageConverterFlags flags, BasisImageConverter::Format fileFormat) {
     /* Check input */
     const PixelFormat pixelFormat = imageLevels.front().format();
     bool isSrgb;
@@ -86,34 +75,51 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
             return {};
     }
 
-    const Vector2i size = imageLevels.front().size();
+    basisu::basis_compressor_params params;
 
-    const UnsignedInt numMipmaps = Math::min<UnsignedInt>(imageLevels.size(), Math::log2(size.max()) + 1);
+    /** @todo Handle different image types (cube/array/volume) once this can be
+        queried from images */
+    Math::Vector<dimensions, Int> mipMask{1};
+    if(dimensions < 3) {
+        /* Basis doesn't support 1D images, we treat them as 2D images with
+           height 1 */
+        params.m_tex_type = basist::basis_texture_type::cBASISTexType2D;
+    } else {
+        /* Encoding 3D images as KTX2 always produces 2D array images and mip
+           levels in .basis files are inherently 2D images, so we always export
+           2D array images. This affects the expected mip sizes and prevents
+           a possible z-flip, so print a warning. */
+        Warning{} << "Trade::BasisImageConverter::convertToData(): exporting 3D image as a 2D array image";
+        params.m_tex_type = basist::basis_texture_type::cBASISTexType2DArray;
+        mipMask[dimensions - 1] = 0;
+    }
+
+    const auto baseSize = imageLevels.front().size();
+    const UnsignedInt numMipmaps = Math::min<UnsignedInt>(imageLevels.size(), Math::log2((baseSize*mipMask).max()) + 1);
+
     if(imageLevels.size() > numMipmaps) {
         Error{} << "Trade::BasisImageConverter::convertToData(): there can be only" << numMipmaps <<
-            "levels with base image size" << imageLevels.front().size() << "but got" << imageLevels.size();
+            "levels with base image size" << baseSize << "but got" << imageLevels.size();
         return {};
     }
 
-    basisu::basis_compressor_params params;
-
-    if(_format == Format::Ktx)
+    if(fileFormat == BasisImageConverter::Format::Ktx)
         params.m_create_ktx2_file = true;
     else
-        CORRADE_INTERNAL_ASSERT(_format == Format{} || _format == Format::Basis);
+        CORRADE_INTERNAL_ASSERT(fileFormat == BasisImageConverter::Format{} || fileFormat == BasisImageConverter::Format::Basis);
 
     /* Options deduced from input data. Config values that are not emptied out
        override these below. */
     params.m_perceptual = isSrgb;
-    params.m_mip_gen = imageLevels.size() == 1;
+    params.m_mip_gen = numMipmaps == 1;
     params.m_mip_srgb = isSrgb;
 
     /* To retain sanity, keep this in the same order and grouping as in the
        conf file */
     #define PARAM_CONFIG(name, type) \
-        if(!configuration().value(#name).empty()) params.m_##name = configuration().value<type>(#name)
+        if(!configuration.value(#name).empty()) params.m_##name = configuration.value<type>(#name)
     #define PARAM_CONFIG_FIX_NAME(name, type, fixed) \
-        if(!configuration().value(fixed).empty()) params.m_##name = configuration().value<type>(fixed)
+        if(!configuration.value(fixed).empty()) params.m_##name = configuration.value<type>(fixed)
     /* Options */
     PARAM_CONFIG(quality_level, int);
     PARAM_CONFIG(perceptual, bool);
@@ -130,7 +136,7 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     PARAM_CONFIG(check_for_alpha, bool);
     PARAM_CONFIG(force_alpha, bool);
 
-    const std::string swizzle = configuration().value("swizzle");
+    const std::string swizzle = configuration.value("swizzle");
     if(!swizzle.empty()) {
         if(swizzle.size() != 4) {
             Error{} << "Trade::BasisImageConverter::convertToData(): invalid swizzle length, expected 4 but got" << swizzle.size();
@@ -158,7 +164,7 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     PARAM_CONFIG(resample_height, int);
     PARAM_CONFIG(resample_factor, float);
 
-    UnsignedInt threadCount = configuration().value<Int>("threads");
+    UnsignedInt threadCount = configuration.value<Int>("threads");
     if(threadCount == 0) threadCount = std::thread::hardware_concurrency();
     const bool multithreading = threadCount > 1;
     params.m_multithreading = multithreading;
@@ -177,6 +183,11 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     PARAM_CONFIG(mip_fast, bool);
     PARAM_CONFIG(mip_smallest_dimension, int);
 
+    if(params.m_mip_gen && numMipmaps > 1) {
+        Warning{} << "Trade::BasisImageConverter::convertToData(): found user-supplied mip levels, ignoring mip_gen config value";
+        params.m_mip_gen = false;
+    }
+
     /* Backend endpoint/selector RDO codec options */
     PARAM_CONFIG(no_selector_rdo, bool);
     PARAM_CONFIG_FIX_NAME(selector_rdo_thresh, float, "selector_rdo_threshold");
@@ -193,7 +204,7 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
 
     /* UASTC options */
     PARAM_CONFIG(uastc, bool);
-    params.m_pack_uastc_flags = configuration().value<Int>("pack_uastc_level");
+    params.m_pack_uastc_flags = configuration.value<Int>("pack_uastc_level");
     PARAM_CONFIG(pack_uastc_flags, int);
     PARAM_CONFIG(rdo_uastc, bool);
     PARAM_CONFIG(rdo_uastc_quality_scalar, float);
@@ -207,14 +218,15 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
 
     /* KTX2 options */
     params.m_ktx2_uastc_supercompression =
-        configuration().value<bool>("ktx2_uastc_supercompression") ? basist::KTX2_SS_ZSTANDARD : basist::KTX2_SS_NONE;
+        configuration.value<bool>("ktx2_uastc_supercompression") ? basist::KTX2_SS_ZSTANDARD : basist::KTX2_SS_NONE;
     PARAM_CONFIG(ktx2_zstd_supercompression_level, int);
     params.m_ktx2_srgb_transfer_func = params.m_perceptual;
 
     /* y_flip sets a flag in Basis files, but not in KTX2 files:
        https://github.com/BinomialLLC/basis_universal/issues/258
        Manually specify the orientation in the key/value data:
-       https://www.khronos.org/registry/KTX/specs/2.0/ktxspec_v2.html#_ktxorientation */
+       https://www.khronos.org/registry/KTX/specs/2.0/ktxspec_v2.html#_ktxorientation
+       Output images are always 2D or 2D arrays. */
     constexpr char OrientationKey[] = "KTXorientation";
     char orientationValue[] = "rd";
     if(params.m_y_flip)
@@ -232,7 +244,7 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     /* Don't spam stdout with debug info by default. Basis error output is
        unaffected by this. Unfortunately, there's no way to redirect the output
        to Debug. */
-    params.m_status_output = flags() >= ImageConverterFlag::Verbose;
+    params.m_status_output = flags >= ImageConverterFlag::Verbose;
 
     /* If these are enabled, the library reads BMPs/JPGs/PNGs/TGAs from the
        filesystem and then writes basis files there also. DO NOT WANT. */
@@ -242,85 +254,99 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     const basist::etc1_global_selector_codebook sel_codebook(basist::g_global_selector_cb_size, basist::g_global_selector_cb);
     params.m_pSel_codebook = &sel_codebook;
 
-    /* The base mip is in m_source_images, mip 1 and higher go into
-       m_source_mipmap_images. If m_source_mipmap_images is not empty, mip
-       generation is disabled. */
-    params.m_source_images.resize(1);
-    if(imageLevels.size() > 1) {
-        if(params.m_mip_gen) {
-            Warning{} << "Trade::BasisImageConverter::convertToData(): found user-supplied mip levels, ignoring mip_gen config value";
-            params.m_mip_gen = false;
-        }
-
-        params.m_source_mipmap_images.resize(1);
-        params.m_source_mipmap_images[0].resize(imageLevels.size() - 1);
+    /* One image per slice. The base mip is in m_source_images, mip 1 and
+       higher go into m_source_mipmap_images. */
+    const UnsignedInt numImages = Vector3i::pad(baseSize, 1).z();
+    params.m_source_images.resize(numImages);
+    if(numMipmaps > 1) {
+        params.m_source_mipmap_images.resize(numImages);
+        for(auto& slice: params.m_source_mipmap_images)
+            slice.resize(numMipmaps - 1);
     }
 
-    for(UnsignedInt i = 0; i != imageLevels.size(); ++i) {
-        const Vector2i mipSize = Math::max(size >> i, 1);
-        const auto& image = imageLevels[i];
-
-        if(image.size() != mipSize) {
+    const UnsignedInt channelCount = pixelSize(pixelFormat);
+    for(UnsignedInt level = 0; level != numMipmaps; ++level) {
+        const auto mipSize = Math::max(baseSize >> level, 1)*mipMask + baseSize*(Math::Vector<dimensions, Int>{1} - mipMask);
+        const auto& image = imageLevels[level];
+        const auto imageBaseSize = image.size();
+        if(imageBaseSize != mipSize) {
             Error{} << "Trade::BasisImageConverter::convertToData(): expected "
-                "size" << mipSize << "for level" << i << "but got" << image.size();
+                "size" << mipSize << "for level" << level << "but got" << imageBaseSize;
             return {};
         }
 
-        /* Copy image data into the basis image. There is no way to construct a
-           basis image from existing data as it is based on basisu::vector,
-           moreover we need to tightly pack it and flip Y. */
-        basisu::image& basisImage = i == 0 ? params.m_source_images[0] : params.m_source_mipmap_images[0][i - 1];
-        basisImage.resize(image.size().x(), image.size().y());
-        auto dst = Containers::arrayCast<Color4ub>(Containers::StridedArrayView2D<basisu::color_rgba>({basisImage.get_ptr(), basisImage.get_total_pixels()}, {std::size_t(image.size().y()), std::size_t(image.size().x())}));
-        /* Y-flip the view to make the following loops simpler. basisu doesn't
-           apply m_y_flip to user-supplied mipmaps, so only do this for the
-           base image:
-           https://github.com/BinomialLLC/basis_universal/issues/257 */
-        if(!params.m_y_flip || i == 0)
-            dst = dst.flipped<0>();
+        /* Make size 1 in missing dimensions for simpler calculations */
+        const Vector3i imageSize = Vector3i::pad(imageBaseSize, 1);
 
-        /* basis image is always RGBA, fill in alpha if necessary */
-        const UnsignedInt channels = pixelSize(pixelFormat);
-        if(channels == 4) {
-            auto src = image.pixels<Math::Vector4<UnsignedByte>>();
-            for(std::size_t y = 0; y != src.size()[0]; ++y)
-                for(std::size_t x = 0; x != src.size()[1]; ++x)
-                    dst[y][x] = src[y][x];
+        /* Insert extra dimensions in the front to always get a 3D view,
+            generalizes indexing for all image types. For e.g. 1D images the
+            view has size (1, 1, width). Last dimensions's stride equals the
+            format size so we can simply arrayCast later for copying. New
+            dimensions have stride 0 so all elements are read from the same
+            address, but that's fine since new dimensions all have size 1. */
+        const std::size_t size[3]{std::size_t(imageSize.z()), std::size_t(imageSize.y()), std::size_t(imageSize.x())};
+        std::ptrdiff_t stride[3]{0, 0, channelCount};
+        for(UnsignedInt i = 0; i != dimensions - 1; ++i)
+            stride[i + 3 - dimensions] = image.pixels().stride()[i];
+        const auto pixelView = Containers::arrayView(static_cast<const char*>(image.pixels().data()), image.pixels().stride()[0] * image.pixels().size()[0]);
+        const Containers::StridedArrayView3D<const char> srcData{pixelView, size, stride};
 
-        } else if(channels == 3) {
-            auto src = image.pixels<Math::Vector3<UnsignedByte>>();
-            for(std::size_t y = 0; y != src.size()[0]; ++y)
-                for(std::size_t x = 0; x != src.size()[1]; ++x)
-                    dst[y][x] = src[y][x]; /* Alpha implicitly 255 */
+        for(UnsignedInt slice = 0; slice != numImages; ++slice) {
+            /* Copy image data into the basis image. There is no way to construct a
+               basis image from existing data as it is based on basisu::vector,
+               moreover we need to tightly pack it and flip Y. */
+            basisu::image& basisImage = level > 0 ? params.m_source_mipmap_images[slice][level - 1] : params.m_source_images[slice];
+            basisImage.resize(imageSize.x(), imageSize.y());
+            auto dst = Containers::arrayCast<Color4ub>(Containers::StridedArrayView2D<basisu::color_rgba>({basisImage.get_ptr(), basisImage.get_total_pixels()}, {std::size_t(imageSize.y()), std::size_t(imageSize.x())}));
+            /* Y-flip the view to make the following loops simpler. basisu doesn't
+               apply m_y_flip to user-supplied mipmaps, so only do this for the
+               base image:
+               https://github.com/BinomialLLC/basis_universal/issues/257 */
+            if(!params.m_y_flip || level == 0)
+                dst = dst.flipped<0>();
 
-        } else if(channels == 2) {
-            auto src = image.pixels<Math::Vector2<UnsignedByte>>();
-            /* If the user didn't specify a custom swizzle, assume they want
-               the two channels compressed in separate slices, R in RGB and G
-               in Alpha. This significantly improves quality. */
-            if(swizzle.empty())
+            /* basis image is always RGBA, fill in alpha if necessary */
+            if(channelCount == 4) {
+                const auto src = Containers::arrayCast<const Math::Vector<4, UnsignedByte>>(srcData[slice]);
                 for(std::size_t y = 0; y != src.size()[0]; ++y)
                     for(std::size_t x = 0; x != src.size()[1]; ++x)
-                        dst[y][x] = Math::gather<'r', 'r', 'r', 'g'>(src[y][x]);
-            else
-                for(std::size_t y = 0; y != src.size()[0]; ++y)
-                    for(std::size_t x = 0; x != src.size()[1]; ++x)
-                        dst[y][x] = Vector3ub::pad(src[y][x]); /* Alpha implicitly 255 */
+                        dst[y][x] = src[y][x];
 
-        } else if(channels == 1) {
-            auto src = image.pixels<Math::Vector<1, UnsignedByte>>();
-            /* If the user didn't specify a custom swizzle, assume they want
-               a gray-scale image. Alpha is always implicitly 255. */
-            if(swizzle.empty())
+            } else if(channelCount == 3) {
+                const auto src = Containers::arrayCast<const Math::Vector<3, UnsignedByte>>(srcData[slice]);
                 for(std::size_t y = 0; y != src.size()[0]; ++y)
                     for(std::size_t x = 0; x != src.size()[1]; ++x)
-                        dst[y][x] = Math::gather<'r', 'r', 'r'>(src[y][x]);
-            else
-                for(std::size_t y = 0; y != src.size()[0]; ++y)
-                    for(std::size_t x = 0; x != src.size()[1]; ++x)
-                        dst[y][x] = Vector3ub::pad(src[y][x]);
+                        dst[y][x] = Vector3ub{src[y][x]}; /* Alpha implicitly 255 */
 
-        } else CORRADE_INTERNAL_ASSERT_UNREACHABLE();
+            } else if(channelCount == 2) {
+                const auto src = Containers::arrayCast<const Math::Vector<2, UnsignedByte>>(srcData[slice]);
+                /* If the user didn't specify a custom swizzle, assume they want
+                   the two channels compressed in separate slices, R in RGB and G
+                   in Alpha. This significantly improves quality. */
+                if(swizzle.empty())
+                    for(std::size_t y = 0; y != src.size()[0]; ++y)
+                        for(std::size_t x = 0; x != src.size()[1]; ++x)
+                            dst[y][x] = Math::gather<'r', 'r', 'r', 'g'>(src[y][x]);
+                else
+                    for(std::size_t y = 0; y != src.size()[0]; ++y)
+                        for(std::size_t x = 0; x != src.size()[1]; ++x)
+                            dst[y][x] = Vector3ub::pad(src[y][x]); /* Alpha implicitly 255 */
+
+            } else if(channelCount == 1) {
+                const auto src = Containers::arrayCast<const Math::Vector<1, UnsignedByte>>(srcData[slice]);
+                /* If the user didn't specify a custom swizzle, assume they want
+                   a gray-scale image. Alpha is always implicitly 255. */
+                if(swizzle.empty())
+                    for(std::size_t y = 0; y != src.size()[0]; ++y)
+                        for(std::size_t x = 0; x != src.size()[1]; ++x)
+                            dst[y][x] = Math::gather<'r', 'r', 'r'>(src[y][x]);
+                else
+                    for(std::size_t y = 0; y != src.size()[0]; ++y)
+                        for(std::size_t x = 0; x != src.size()[1]; ++x)
+                            dst[y][x] = Vector3ub::pad(src[y][x]);
+
+            } else CORRADE_INTERNAL_ASSERT_UNREACHABLE();
+        }
     }
 
     basisu::basis_compressor basis;
@@ -364,7 +390,6 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
             /* We do not write any files, just data */
         default:
             CORRADE_INTERNAL_ASSERT_UNREACHABLE();
-            return {};
         /* LCOV_EXCL_STOP */
     }
 
@@ -376,7 +401,38 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     return fileData;
 }
 
-bool BasisImageConverter::doConvertToFile(const Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) {
+}
+
+BasisImageConverter::BasisImageConverter(Format format): _format{format} {
+    /* Passing an invalid Format enum is user error, we'll assert on that in
+       the convertToData() function */
+}
+
+BasisImageConverter::BasisImageConverter(PluginManager::AbstractManager& manager, const std::string& plugin): AbstractImageConverter{manager, plugin} {
+    if(plugin == "BasisKtxImageConverter")
+        _format = Format::Ktx;
+    else
+        _format = {}; /* Overridable by openFile() */
+}
+
+ImageConverterFeatures BasisImageConverter::doFeatures() const {
+    return ImageConverterFeature::ConvertLevels1DToData | ImageConverterFeature::ConvertLevels2DToData | ImageConverterFeature::ConvertLevels3DToData;
+}
+
+Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayView<const ImageView1D> imageLevels) {
+    return convertLevelsToData(imageLevels, configuration(), flags(), _format);
+}
+
+Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) {
+    return convertLevelsToData(imageLevels, configuration(), flags(), _format);
+}
+
+Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) {
+    return convertLevelsToData(imageLevels, configuration(), flags(), _format);
+}
+
+template<UnsignedInt dimensions>
+bool BasisImageConverter::convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename) {
     /** @todo once Directory is std::string-free, use splitExtension() */
     const Containers::String normalized = Utility::String::lowercase(filename);
 
@@ -396,6 +452,18 @@ bool BasisImageConverter::doConvertToFile(const Containers::ArrayView<const Imag
     /* Restore the previous format and return the result */
     _format = previousFormat;
     return out;
+}
+
+bool BasisImageConverter::doConvertToFile(Containers::ArrayView<const ImageView1D> imageLevels, const Containers::StringView filename) {
+    return convertLevelsToFile(imageLevels, filename);
+}
+
+bool BasisImageConverter::doConvertToFile(Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) {
+    return convertLevelsToFile(imageLevels, filename);
+}
+
+bool BasisImageConverter::doConvertToFile(Containers::ArrayView<const ImageView3D> imageLevels, const Containers::StringView filename) {
+    return convertLevelsToFile(imageLevels, filename);
 }
 
 }}

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.cpp
@@ -52,8 +52,7 @@ using namespace Containers::Literals;
 
 namespace {
 
-template<UnsignedInt dimensions>
-Containers::Array<char> convertLevelsToData(Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Utility::ConfigurationGroup& configuration, ImageConverterFlags flags, BasisImageConverter::Format fileFormat) {
+template<UnsignedInt dimensions> Containers::Array<char> convertLevelsToData(Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Utility::ConfigurationGroup& configuration, ImageConverterFlags flags, BasisImageConverter::Format fileFormat) {
     /* Check input */
     const PixelFormat pixelFormat = imageLevels.front().format();
     bool isSrgb;
@@ -412,8 +411,7 @@ Containers::Array<char> BasisImageConverter::doConvertToData(Containers::ArrayVi
     return convertLevelsToData(imageLevels, configuration(), flags(), _format);
 }
 
-template<UnsignedInt dimensions>
-bool BasisImageConverter::convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename) {
+template<UnsignedInt dimensions> bool BasisImageConverter::convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename) {
     /** @todo once Directory is std::string-free, use splitExtension() */
     const Containers::String normalized = Utility::String::lowercase(filename);
 

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
@@ -61,7 +61,7 @@ namespace Magnum { namespace Trade {
 @m_keywords{BasisKtxImageConverter}
 
 Creates [Basis Universal](https://github.com/binomialLLC/basis_universal)
-compressed image files (`*.basis` or `*.ktx2`) from 1D, 2D and 3D images with
+compressed image files (`*.basis` or `*.ktx2`) from 2D and 2D array images with
 optional mip levels. You can use @ref BasisImporter to import images in this
 format.
 
@@ -127,8 +127,6 @@ The @ref PixelFormat::R8Unorm, @relativeref{PixelFormat,R8Srgb},
 formats are supported.
 
 @subsection Trade-BasisImageConverter-behavior-types Image types
-
-1D images will be saved as 2D images with height 1.
 
 Cube map images can be written but there is currently no way to mark them
 properly in the metadata. Exported files will be 2D array images with faces
@@ -238,14 +236,12 @@ class MAGNUM_BASISIMAGECONVERTER_EXPORT BasisImageConverter: public AbstractImag
     private:
         MAGNUM_BASISIMAGECONVERTER_LOCAL ImageConverterFeatures doFeatures() const override;
 
-        MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView1D> imageLevels) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
 
         template<UnsignedInt dimensions>
         bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
 
-        MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView1D> imageLevels, const Containers::StringView filename) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView3D> imageLevels, const Containers::StringView filename) override;
 

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
@@ -61,8 +61,9 @@ namespace Magnum { namespace Trade {
 @m_keywords{BasisKtxImageConverter}
 
 Creates [Basis Universal](https://github.com/binomialLLC/basis_universal)
-compressed image files (`*.basis` or `*.ktx2`) from 2D images with optional mip
-levels. You can use @ref BasisImporter to import images in this format.
+compressed image files (`*.basis` or `*.ktx2`) from 1D, 2D and 3D images with
+optional mip levels. You can use @ref BasisImporter to import images in this
+format.
 
 This plugin provides `BasisKtxImageConverter`.
 
@@ -125,12 +126,30 @@ The @ref PixelFormat::R8Unorm, @relativeref{PixelFormat,R8Srgb},
 @relativeref{PixelFormat,RGBA8Unorm} and @relativeref{PixelFormat,RGBA8Srgb}
 formats are supported.
 
+@subsection Trade-BasisImageConverter-behavior-types Image types
+
+1D images will be saved as 2D images with height 1.
+
+Cube map images can be written but there is currently no way to mark them
+properly in the metadata. Exported files will be 2D array images with faces
+exposed as layers.
+
+3D images will be saved as 2D array images with one layer per depth slice. This
+is necessary because mip levels are always 2-dimensional in Basis compressed
+images. Note that this matches @ref BasisImporter behavior which imports all 3D
+images as 2D array images anyway because of the same Basis limitation.
+
 @subsection Trade-BasisImageConverter-behavior-multilevel Multilevel images
 
 Images can be saved with multiple levels by using the list variants of
 @ref convertToFile() / @ref convertToData(). Largest level is expected to be
-first, with each following level having width and height divided by two,
+first, with each following level having width, height and depth divided by two,
 rounded down. Incomplete mip chains are supported.
+
+Due to the way @ref Trade-BasisImageConverter-behavior-types "non-trivial image types"
+are handled, the level sizes are always expected to match the resulting image
+type. Specifically that means 1D array images and 3D images with multiple
+levels can currently not be exported and produce a level size mismatch error.
 
 To generate mip levels from a single top-level image instead, you can use the
 @cb{.ini} mip_gen @ce @ref Trade-BasisImageConverter-configuration "configuration option".
@@ -218,8 +237,17 @@ class MAGNUM_BASISIMAGECONVERTER_EXPORT BasisImageConverter: public AbstractImag
 
     private:
         MAGNUM_BASISIMAGECONVERTER_LOCAL ImageConverterFeatures doFeatures() const override;
+
+        MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView1D> imageLevels) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
+        MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
+
+        template<UnsignedInt dimensions>
+        bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
+
+        MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView1D> imageLevels, const Containers::StringView filename) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) override;
+        MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView3D> imageLevels, const Containers::StringView filename) override;
 
         Format _format;
 };

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
@@ -233,7 +233,7 @@ class MAGNUM_BASISIMAGECONVERTER_EXPORT BasisImageConverter: public AbstractImag
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
 
-        template<UnsignedInt dimensions> bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
+        template<UnsignedInt dimensions> MAGNUM_BASISIMAGECONVERTER_LOCAL bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
 
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView3D> imageLevels, const Containers::StringView filename) override;

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
@@ -128,26 +128,20 @@ formats are supported.
 
 @subsection Trade-BasisImageConverter-behavior-types Image types
 
+The exporter can save 2D and 2D array images. Even though the KTX container
+format supports 1D and 3D images, Basis Universal doesn't.
+
 Cube map images can be written but there is currently no way to mark them
 properly in the metadata. Exported files will be 2D array images with faces
 exposed as layers.
-
-3D images will be saved as 2D array images with one layer per depth slice. This
-is necessary because mip levels are always 2-dimensional in Basis compressed
-images. Note that this matches @ref BasisImporter behavior which imports all 3D
-images as 2D array images anyway because of the same Basis limitation.
 
 @subsection Trade-BasisImageConverter-behavior-multilevel Multilevel images
 
 Images can be saved with multiple levels by using the list variants of
 @ref convertToFile() / @ref convertToData(). Largest level is expected to be
-first, with each following level having width, height and depth divided by two,
-rounded down. Incomplete mip chains are supported.
-
-Due to the way @ref Trade-BasisImageConverter-behavior-types "non-trivial image types"
-are handled, the level sizes are always expected to match the resulting image
-type. Specifically that means 1D array images and 3D images with multiple
-levels can currently not be exported and produce a level size mismatch error.
+first, with each following level having width and height divided by two,
+rounded down. Because only 2D array images are supported, depth has to have the
+same size in all levels. Incomplete mip chains are supported.
 
 To generate mip levels from a single top-level image instead, you can use the
 @cb{.ini} mip_gen @ce @ref Trade-BasisImageConverter-configuration "configuration option".

--- a/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
+++ b/src/MagnumPlugins/BasisImageConverter/BasisImageConverter.h
@@ -239,8 +239,7 @@ class MAGNUM_BASISIMAGECONVERTER_EXPORT BasisImageConverter: public AbstractImag
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
 
-        template<UnsignedInt dimensions>
-        bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
+        template<UnsignedInt dimensions> bool convertLevelsToFile(const Containers::ArrayView<const BasicImageView<dimensions>> imageLevels, const Containers::StringView filename);
 
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView2D> imageLevels, const Containers::StringView filename) override;
         MAGNUM_BASISIMAGECONVERTER_LOCAL bool doConvertToFile(const Containers::ArrayView<const ImageView3D> imageLevels, const Containers::StringView filename) override;

--- a/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
@@ -129,29 +129,29 @@ constexpr PixelFormat TransferFunctionFormats[2][4]{
 constexpr struct {
     const char* name;
     const TransferFunction transferFunction;
-} FormatTransferFunctionData[] {
+} FormatTransferFunctionData[]{
     {"Unorm", TransferFunction::Linear},
     {"Srgb", TransferFunction::Srgb}
 };
 
-constexpr Containers::StringView BasisPrefix = "sB"_s;
-constexpr Containers::StringView KtxPrefix = "\xabKTX"_s;
+constexpr const char* BasisFileMagic = "sB";
+constexpr const char* KtxFileMagic = "\xabKTX";
 
 constexpr struct {
     const char* name;
     const char* pluginName;
     const char* filename;
-    const Containers::StringView prefix;
-} ConvertToFileData[] {
-    {"Basis", "BasisImageConverter", "image.basis", BasisPrefix},
-    {"KTX2", "BasisImageConverter", "image.ktx2", KtxPrefix},
-    {"KTX2 with explicit plugin name", "BasisKtxImageConverter", "image.foo", KtxPrefix}
+    const char* prefix;
+} ConvertToFileData[]{
+    {"Basis", "BasisImageConverter", "image.basis", BasisFileMagic},
+    {"KTX2", "BasisImageConverter", "image.ktx2", KtxFileMagic},
+    {"KTX2 with explicit plugin name", "BasisKtxImageConverter", "image.foo", KtxFileMagic}
 };
 
 constexpr struct {
     const char* name;
     const char* threads;
-} ThreadsData[] {
+} ThreadsData[]{
     {"", nullptr},
     {"2 threads", "2"},
     {"all threads", "0"}
@@ -160,7 +160,7 @@ constexpr struct {
 constexpr struct {
     const char* name;
     const bool yFlip;
-} FlippedData[] {
+} FlippedData[]{
     {"y-flip", true},
     {"no y-flip", false}
 };
@@ -248,8 +248,7 @@ BasisImageConverterTest::BasisImageConverterTest() {
 }
 
 void BasisImageConverterTest::wrongFormat() {
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
 
     const char data[8]{};
     std::ostringstream out;
@@ -270,8 +269,7 @@ void BasisImageConverterTest::unknownOutputFormatData() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(converted));
 }
 
@@ -288,14 +286,12 @@ void BasisImageConverterTest::unknownOutputFormatFile() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openFile(filename));
 }
 
 void BasisImageConverterTest::invalidSwizzle() {
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
 
     const char data[8]{};
     std::ostringstream out;
@@ -379,8 +375,7 @@ void BasisImageConverterTest::levelWrongSize() {
 }
 
 void BasisImageConverterTest::processError() {
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     converter->configuration().setValue("max_endpoint_clusters",
         16128 /* basisu_frontend::cMaxEndpointClusters */ + 1);
 
@@ -398,8 +393,7 @@ void BasisImageConverterTest::configPerceptual() {
     const char bytes[4]{};
     ImageView2D originalImage{PixelFormat::RGBA8Unorm, Vector2i{1}, bytes};
 
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     /* Empty by default */
     CORRADE_COMPARE(converter->configuration().value("perceptual"), "");
 
@@ -414,8 +408,7 @@ void BasisImageConverterTest::configPerceptual() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
 
     /* Empty perceptual config means to use the image format to determine if
        the output data should be sRGB */
@@ -436,8 +429,7 @@ void BasisImageConverterTest::configMipGen() {
     ImageView2D originalLevel0{PixelFormat::RGBA8Unorm, Vector2i{16}, bytes};
     ImageView2D originalLevel1{PixelFormat::RGBA8Unorm, Vector2i{8}, bytes};
 
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     /* Empty by default */
     CORRADE_COMPARE(converter->configuration().value<bool>("mip_gen"), false);
     converter->configuration().setValue("mip_gen", "");
@@ -451,8 +443,7 @@ void BasisImageConverterTest::configMipGen() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
 
     /* Empty mip_gen config means to use the level count to determine if mip
        levels should be generated */
@@ -519,8 +510,7 @@ void BasisImageConverterTest::convert1D() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     /* BasisImageConverter writes 1D images as 2D images with height 1 */
     CORRADE_COMPARE(importer->image1DCount(), 0);
@@ -565,18 +555,16 @@ void BasisImageConverterTest::convert1DMipmaps() {
         level.imageWithSkip = copyImageWithSkip<Color4ub>(*level.originalImage1D, {7});
     }
 
-    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
-
     /* Interaction with mip_gen config option is tested in convert2DMipmaps() */
 
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     const auto compressedData = converter->convertToData({*levels[0].imageWithSkip, *levels[1].imageWithSkip, *levels[2].imageWithSkip});
     CORRADE_VERIFY(compressedData);
 
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     /* BasisImageConverter writes 1D images as 2D images with height 1 */
     CORRADE_COMPARE(importer->image1DCount(), 0);
@@ -619,14 +607,14 @@ void BasisImageConverterTest::convert2DR() {
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub, Math::Vector<1, UnsignedByte>>(
         ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][0]);
 
-    const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
 
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
@@ -639,7 +627,7 @@ void BasisImageConverterTest::convert2DR() {
         TransferFunctionFormats[TransferFunction::Linear][0], imageWithSkip.size(), imageWithSkip.data()};
     /* Basis can only load RGBA8 uncompressed data, which corresponds to RRR1
        from our R8 image data. We chose the red channel from the imported image
-       to compare to our original data */
+       to compare to our original data. */
     CORRADE_COMPARE_WITH(
         (Containers::arrayCast<2, const UnsignedByte>(image->pixels().prefix(
             {std::size_t(image->size()[1]), std::size_t(image->size()[0]), 1}))),
@@ -666,14 +654,14 @@ void BasisImageConverterTest::convert2DRg() {
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub, Vector2ub>(
         ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][1]);
 
-    const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
 
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
@@ -686,7 +674,7 @@ void BasisImageConverterTest::convert2DRg() {
         TransferFunctionFormats[TransferFunction::Linear][1], imageWithSkip.size(), imageWithSkip.data()};
     /* Basis can only load RGBA8 uncompressed data, which corresponds to RRRG
        from our RG8 image data. We chose the B and A channels from the imported
-       image to compare to our original data */
+       image to compare to our original data. */
     CORRADE_COMPARE_WITH(
         (Containers::arrayCast<2, const Math::Vector2<UnsignedByte>>(image->pixels().suffix({0, 0, 2}))),
         imageViewUnorm,
@@ -711,14 +699,14 @@ void BasisImageConverterTest::convert2DRgb() {
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub>(
         ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][2]);
 
-    const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
 
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
@@ -755,16 +743,13 @@ void BasisImageConverterTest::convert2DRgba() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
     CORRADE_VERIFY(!image->isCompressed());
     CORRADE_COMPARE(image->format(), TransferFunctionFormats[data.transferFunction][3]);
 
-    /* Basis can only load RGBA8 uncompressed data, which corresponds to RGB1
-       from our RGB8 image data. */
     CORRADE_COMPARE_WITH(image->pixels<Color4ub>(),
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
@@ -816,8 +801,7 @@ void BasisImageConverterTest::convert2DMipmaps() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     CORRADE_COMPARE(importer->image2DCount(), 1);
     CORRADE_COMPARE(importer->image2DLevelCount(0), Containers::arraySize(levels));
@@ -878,8 +862,7 @@ void BasisImageConverterTest::convert2DArray() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     CORRADE_COMPARE(importer->image3DCount(), 1);
     CORRADE_COMPARE(importer->textureCount(), 1);
@@ -950,8 +933,7 @@ void BasisImageConverterTest::convert2DArrayMipmaps() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     CORRADE_COMPARE(importer->image3DCount(), 1);
     CORRADE_COMPARE(importer->image3DLevelCount(0), Containers::arraySize(levels));
@@ -1022,15 +1004,17 @@ void BasisImageConverterTest::convertToFile() {
     CORRADE_VERIFY(importer->openFile(filename));
     CORRADE_COMPARE(importer->image2DCount(), 1);
     CORRADE_COMPARE(importer->image2DLevelCount(0), 2);
+
     Containers::Optional<Trade::ImageData2D> level0 = importer->image2D(0, 0);
     Containers::Optional<Trade::ImageData2D> level1 = importer->image2D(0, 1);
     CORRADE_VERIFY(level0);
     CORRADE_VERIFY(level1);
-    CORRADE_COMPARE_WITH(level0->pixels<Color4ub>(),
+
+    CORRADE_COMPARE_WITH(*level0,
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
         (DebugTools::CompareImageToFile{_manager, 97.25f, 7.882f}));
-    CORRADE_COMPARE_WITH(level1->pixels<Color4ub>(),
+    CORRADE_COMPARE_WITH(*level1,
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-31x13.png"),
         /* There are moderately significant compression artifacts */
         (DebugTools::CompareImageToFile{_manager, 81.0f, 14.31f}));
@@ -1040,7 +1024,7 @@ void BasisImageConverterTest::convertToFile() {
     if(data.pluginName == "BasisImageConverter"_s) {
         const auto compressedData = converter->convertToData(originalLevels);
         CORRADE_VERIFY(compressedData);
-        CORRADE_VERIFY(Containers::StringView{Containers::arrayView(compressedData)}.hasPrefix(BasisPrefix));
+        CORRADE_VERIFY(Containers::StringView{Containers::arrayView(compressedData)}.hasPrefix(BasisFileMagic));
     }
 }
 
@@ -1068,14 +1052,11 @@ void BasisImageConverterTest::threads() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
 
-    /* Basis can only load RGBA8 uncompressed data, which corresponds to RGB1
-       from our RGB8 image data. */
     CORRADE_COMPARE_WITH(image->pixels<Color4ub>(),
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
@@ -1105,7 +1086,7 @@ void BasisImageConverterTest::ktx() {
     CORRADE_VERIFY(compressedData);
     const Containers::StringView compressedView{Containers::arrayView(compressedData)};
 
-    CORRADE_VERIFY(compressedView.hasPrefix(KtxPrefix));
+    CORRADE_VERIFY(compressedView.hasPrefix(KtxFileMagic));
 
     char KTXorientation[] = "KTXorientation\0r?";
     KTXorientation[sizeof(KTXorientation) - 1] = data.yFlip ? 'u' : 'd';
@@ -1114,8 +1095,7 @@ void BasisImageConverterTest::ktx() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     Containers::Optional<Trade::ImageData2D> image = importer->image2D(0);
     CORRADE_VERIFY(image);
@@ -1148,8 +1128,7 @@ void BasisImageConverterTest::swizzle() {
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");
 
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
     CORRADE_VERIFY(importer->openData(compressedData));
     CORRADE_COMPARE(importer->image2DCount(), 1);
 

--- a/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
@@ -886,6 +886,47 @@ void BasisImageConverterTest::convert2DArray() {
         (DebugTools::CompareImage{96.5f, 6.928f}));
 }
 
+void BasisImageConverterTest::convert2DArrayOneLayer() {
+    auto&& data = Convert2DArrayOneLayerData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    /* For KTX2 files, basis_universal treats 2D array images with one layer
+       as standard 2D images:
+       https://github.com/BinomialLLC/basis_universal/blob/928a0caa3e5db2d4748bce6b23507757f9867d14/encoder/basisu_comp.cpp#L1809 */
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png")));
+    const auto originalImage = pngImporter->image2D(0);
+    CORRADE_VERIFY(originalImage);
+
+    const ImageView3D originalImage3D = padImageView<3>(ImageView2D(*originalImage));
+
+    std::ostringstream out;
+    Warning redirectWarning{&out};
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate(data.pluginName);
+    const auto compressedData = converter->convertToData(originalImage3D);
+    CORRADE_VERIFY(compressedData);
+    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): exporting 3D image as a 2D array image\n");
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer = _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    CORRADE_COMPARE(importer->textureCount(), 1);
+    {
+        CORRADE_EXPECT_FAIL_IF(data.pluginName == "BasisKtxImageConverter"_s,
+            "basis_universal exports KTX2 2D array images with a single layer as 2D images.");
+        CORRADE_COMPARE(importer->image3DCount(), 1);
+        const auto texture = importer->texture(0);
+        CORRADE_COMPARE(texture->type(), TextureType::Texture2DArray);
+    }
+}
+
 void BasisImageConverterTest::convert2DArrayMipmaps() {
     if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("PngImporter plugin not found, cannot test contents");

--- a/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
@@ -503,9 +503,13 @@ void BasisImageConverterTest::convert1D() {
     const ImageView1D originalImage1D = padImageView<1>(ImageView2D(*originalImage));
     const Image1D imageWithSkip = copyImageWithSkip<Color4ub>(originalImage1D, {7});
 
+    std::ostringstream out;
+    Warning redirectWarning{&out};
+
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     const auto compressedData = converter->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
+    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): exporting 1D image as a 2D image with height 1\n");
 
     if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
         CORRADE_SKIP("BasisImporter plugin not found, cannot test");

--- a/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
+++ b/src/MagnumPlugins/BasisImageConverter/Test/BasisImageConverterTest.cpp
@@ -37,14 +37,17 @@
 #include <Corrade/Utility/ConfigurationGroup.h>
 #include <Corrade/Utility/DebugStl.h>
 #include <Corrade/Utility/Directory.h>
+#include <Corrade/Utility/FormatStl.h>
 #include <Magnum/DebugTools/CompareImage.h>
 #include <Magnum/Image.h>
 #include <Magnum/ImageView.h>
 #include <Magnum/Math/Color.h>
+#include <Magnum/Math/Swizzle.h>
 #include <Magnum/PixelFormat.h>
 #include <Magnum/Trade/AbstractImageConverter.h>
 #include <Magnum/Trade/AbstractImporter.h>
 #include <Magnum/Trade/ImageData.h>
+#include <Magnum/Trade/TextureData.h>
 
 #include "configure.h"
 
@@ -64,16 +67,22 @@ struct BasisImageConverterTest: TestSuite::Tester {
     void configPerceptual();
     void configMipGen();
 
-    void r();
-    void rg();
-    void rgb();
-    void rgba();
+    void convert1D();
+    void convert1DMipmaps();
+
+    void convert2DR();
+    void convert2DRg();
+    void convert2DRgb();
+    void convert2DRgba();
+    void convert2DMipmaps();
+
+    void convert2DArray();
+    void convert2DArrayMipmaps();
 
     void convertToFile();
 
     void threads();
     void ktx();
-    void customLevels();
     void swizzle();
 
     /* Explicitly forbid system-wide plugin dependencies */
@@ -84,6 +93,28 @@ struct BasisImageConverterTest: TestSuite::Tester {
 };
 
 using namespace Containers::Literals;
+
+constexpr struct {
+    const char* name;
+    const Vector3i size;
+    const char* message;
+} TooManyLevelsData[]{
+    {"1D", {1, 0, 0}, "there can be only 1 levels with base image size Vector(1) but got 2"},
+    {"2D", {1, 1, 0}, "there can be only 1 levels with base image size Vector(1, 1) but got 2"},
+    /* 3D images are treated like and exported as 2D array images */
+    {"2D array", {1, 1, 2}, "there can be only 1 levels with base image size Vector(1, 1, 2) but got 2"}
+};
+
+constexpr struct {
+    const char* name;
+    const Vector3i sizes[2];
+    const char* message;
+} LevelWrongSizeData[]{
+    {"1D", {{4, 0, 0}, {3, 0, 0}}, "expected size Vector(2) for level 1 but got Vector(3)"},
+    {"2D", {{4, 5, 0}, {2, 1, 0}}, "expected size Vector(2, 2) for level 1 but got Vector(2, 1)"},
+    /* 3D images are treated like and exported as 2D array images */
+    {"2D array", {{4, 5, 3}, {2, 2, 1}}, "expected size Vector(2, 2, 3) for level 1 but got Vector(2, 2, 1)"}
+};
 
 enum TransferFunction: std::size_t {
     Linear,
@@ -151,19 +182,32 @@ BasisImageConverterTest::BasisImageConverterTest() {
     addTests({&BasisImageConverterTest::wrongFormat,
               &BasisImageConverterTest::unknownOutputFormatData,
               &BasisImageConverterTest::unknownOutputFormatFile,
-              &BasisImageConverterTest::invalidSwizzle,
-              &BasisImageConverterTest::tooManyLevels,
-              &BasisImageConverterTest::levelWrongSize,
-              &BasisImageConverterTest::processError,
+              &BasisImageConverterTest::invalidSwizzle});
+
+    addInstancedTests({&BasisImageConverterTest::tooManyLevels},
+        Containers::arraySize(TooManyLevelsData));
+
+    addInstancedTests({&BasisImageConverterTest::levelWrongSize},
+        Containers::arraySize(LevelWrongSizeData));
+
+    addTests({&BasisImageConverterTest::processError,
 
               &BasisImageConverterTest::configPerceptual,
               &BasisImageConverterTest::configMipGen});
 
-    addInstancedTests({&BasisImageConverterTest::r,
-                       &BasisImageConverterTest::rg,
-                       &BasisImageConverterTest::rgb,
-                       &BasisImageConverterTest::rgba},
+    addTests({&BasisImageConverterTest::convert1D,
+              &BasisImageConverterTest::convert1DMipmaps});
+
+    addInstancedTests({&BasisImageConverterTest::convert2DR,
+                       &BasisImageConverterTest::convert2DRg,
+                       &BasisImageConverterTest::convert2DRgb,
+                       &BasisImageConverterTest::convert2DRgba},
         Containers::arraySize(FormatTransferFunctionData));
+
+    addTests({&BasisImageConverterTest::convert2DMipmaps,
+
+              &BasisImageConverterTest::convert2DArray,
+              &BasisImageConverterTest::convert2DArrayMipmaps});
 
     addInstancedTests({&BasisImageConverterTest::convertToFile},
         Containers::arraySize(ConvertToFileData));
@@ -173,8 +217,6 @@ BasisImageConverterTest::BasisImageConverterTest() {
 
     addInstancedTests({&BasisImageConverterTest::ktx},
         Containers::arraySize(FlippedData));
-
-    addTests({&BasisImageConverterTest::customLevels});
 
     addInstancedTests({&BasisImageConverterTest::swizzle},
         Containers::arraySize(SwizzleData));
@@ -271,35 +313,69 @@ void BasisImageConverterTest::invalidSwizzle() {
 }
 
 void BasisImageConverterTest::tooManyLevels() {
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    auto&& data = TooManyLevelsData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
 
-    const UnsignedByte bytes[4]{};
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+
+    const UnsignedByte bytes[8]{};
+    CORRADE_INTERNAL_ASSERT(Math::max(Vector3ui{data.size}, 1u).product() <= Containers::arraySize(bytes));
+
+    const UnsignedInt dimensions = Math::min(Vector3ui{data.size}, 1u).sum();
 
     std::ostringstream out;
     Error redirectError{&out};
-    CORRADE_VERIFY(!converter->convertToData({
-        ImageView2D{PixelFormat::RGB8Unorm, {1, 1}, bytes},
-        ImageView2D{PixelFormat::RGB8Unorm, {1, 1}, bytes}
-    }));
-    CORRADE_COMPARE(out.str(),
-        "Trade::BasisImageConverter::convertToData(): there can be only 1 levels with base image size Vector(1, 1) but got 2\n");
+    if(dimensions == 1) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView1D{PixelFormat::R8Unorm, data.size.x(), bytes},
+            ImageView1D{PixelFormat::R8Unorm, data.size.x(), bytes}
+        }));
+    } else if(dimensions == 2) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView2D{PixelFormat::R8Unorm, data.size.xy(), bytes},
+            ImageView2D{PixelFormat::R8Unorm, data.size.xy(), bytes}
+        }));
+    } else if(dimensions == 3) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView3D{PixelFormat::R8Unorm, data.size, bytes},
+            ImageView3D{PixelFormat::R8Unorm, data.size, bytes}
+        }));
+    }
+
+    CORRADE_COMPARE(out.str(), Utility::formatString("Trade::BasisImageConverter::convertToData(): {}\n", data.message));
 }
 
 void BasisImageConverterTest::levelWrongSize() {
-    Containers::Pointer<AbstractImageConverter> converter =
-        _converterManager.instantiate("BasisImageConverter");
+    auto&& data = LevelWrongSizeData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
 
-    const UnsignedByte bytes[16]{};
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+
+    const UnsignedByte bytes[256]{};
+    CORRADE_INTERNAL_ASSERT(Math::max(Vector3ui{data.sizes[0]}, 1u).product()*4u <= Containers::arraySize(bytes));
+
+    const UnsignedInt dimensions = Math::min(Vector3ui{data.sizes[0]}, 1u).sum();
 
     std::ostringstream out;
     Error redirectError{&out};
-    CORRADE_VERIFY(!converter->convertToData({
-        ImageView2D{PixelFormat::RGB8Unorm, {2, 2}, bytes},
-        ImageView2D{PixelFormat::RGB8Unorm, {2, 1}, bytes}
-    }));
-    CORRADE_COMPARE(out.str(),
-        "Trade::BasisImageConverter::convertToData(): expected size Vector(1, 1) for level 1 but got Vector(2, 1)\n");
+    if(dimensions == 1) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView1D{PixelFormat::RGBA8Unorm, data.sizes[0].x(), bytes},
+            ImageView1D{PixelFormat::RGBA8Unorm, data.sizes[1].x(), bytes}
+        }));
+    } else if(dimensions == 2) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView2D{PixelFormat::RGBA8Unorm, data.sizes[0].xy(), bytes},
+            ImageView2D{PixelFormat::RGBA8Unorm, data.sizes[1].xy(), bytes}
+        }));
+    } else if(dimensions == 3) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView3D{PixelFormat::RGBA8Unorm, data.sizes[0], bytes},
+            ImageView3D{PixelFormat::RGBA8Unorm, data.sizes[1], bytes}
+        }));
+    }
+
+    CORRADE_COMPARE(out.str(), Utility::formatString("Trade::BasisImageConverter::convertToData(): {}\n", data.message));
 }
 
 void BasisImageConverterTest::processError() {
@@ -387,22 +463,145 @@ void BasisImageConverterTest::configMipGen() {
     CORRADE_COMPARE(importer->image2DLevelCount(0), 2);
 }
 
-template<typename SourceType, typename DestinationType = SourceType>
-Image2D copyImageWithSkip(const ImageView2D& originalImage, Vector3i skip, PixelFormat format) {
-    const Vector2i size = originalImage.size();
+template<typename SourceType, typename DestinationType = SourceType, UnsignedInt dimensions>
+Image<dimensions> copyImageWithSkip(const BasicImageView<dimensions>& image, Math::Vector<dimensions, Int> skip, PixelFormat format = PixelFormat{}) {
+    const auto size = image.size();
+    if(format == PixelFormat{})
+        format = image.format();
     /* Width includes row alignment to 4 bytes */
     const UnsignedInt formatSize = pixelSize(format);
-    const UnsignedInt widthWithSkip = ((size.x() + skip.x())*DestinationType::Size + 3)/formatSize*formatSize;
-    const UnsignedInt dataSize = widthWithSkip*(size.y() + skip.y());
-    Image2D imageWithSkip{PixelStorage{}.setSkip(skip), format,
+    const UnsignedInt widthWithSkip = ((size[0] + skip[0])*DestinationType::Size + 3)/formatSize*formatSize;
+    const UnsignedInt dataSize = widthWithSkip*(size + skip).product()/(size[0] + skip[0]);
+    Image<dimensions> imageWithSkip{PixelStorage{}.setSkip(Vector3i::pad(skip)), format,
         size, Containers::Array<char>{ValueInit, dataSize}};
     Utility::copy(Containers::arrayCast<const DestinationType>(
-        originalImage.pixels<SourceType>()),
-        imageWithSkip.pixels<DestinationType>());
+        image.template pixels<SourceType>()),
+        imageWithSkip.template pixels<DestinationType>());
     return imageWithSkip;
 }
 
-void BasisImageConverterTest::r() {
+/* Add/remove dimensions, e.g. turn 1D image into Wx1 2D image or create a 1D
+   image from the first row of a 2D image */
+template<UnsignedInt newDimensions, UnsignedInt dimensions>
+BasicImageView<newDimensions> padImageView(const BasicImageView<dimensions>& image, Int slice = 0) {
+    CORRADE_INTERNAL_ASSERT(image.storage().skip() == Vector3i{});
+    std::size_t stride;
+    const void* data;
+    if(newDimensions < dimensions) {
+        stride = image.pixels().stride()[0];
+        data = image.pixels().slice(slice, slice + 1).data();
+    } else {
+        stride = image.pixels().stride()[0]*image.size()[dimensions - 1];
+        data = image.pixels().data();
+    }
+    return BasicImageView<newDimensions>{image.storage(), image.format(),
+        Math::Vector<newDimensions, Int>::pad(image.size(), 1), Containers::arrayView(data, stride)};
+}
+
+void BasisImageConverterTest::convert1D() {
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png")));
+    const auto originalImage = pngImporter->image2D(0);
+    CORRADE_VERIFY(originalImage);
+
+    /* Use the first row of the original image and add a skip to ensure the
+       converter reads the image data properly */
+    const ImageView1D originalImage1D = padImageView<1>(ImageView2D(*originalImage));
+    const Image1D imageWithSkip = copyImageWithSkip<Color4ub>(originalImage1D, {7});
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData(imageWithSkip);
+    CORRADE_VERIFY(compressedData);
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer =
+        _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    /* BasisImageConverter writes 1D images as 2D images with height 1 */
+    CORRADE_COMPARE(importer->image1DCount(), 0);
+    CORRADE_COMPARE(importer->image2DCount(), 1);
+
+    const auto image = importer->image2D(0);
+    CORRADE_VERIFY(image);
+    CORRADE_COMPARE(image->size().y(), 1);
+    CORRADE_COMPARE_WITH(*image, padImageView<2>(originalImage1D),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{42.25f, 5.048f}));
+}
+
+void BasisImageConverterTest::convert1DMipmaps() {
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+
+    struct Level {
+        const char* file;
+        Containers::Optional<ImageData2D> originalImage;
+        Containers::Optional<ImageView1D> originalImage1D;
+        Containers::Optional<Image1D> imageWithSkip;
+        Containers::Optional<ImageData2D> result;
+    } levels[3] {
+        {"rgba-63x27.png", {}, {}, {}, {}},
+        {"rgba-31x13.png", {}, {}, {}, {}},
+        {"rgba-15x6.png", {}, {}, {}, {}}
+    };
+
+    for(Level& level: levels) {
+        CORRADE_ITERATION(level.file);
+        CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, level.file)));
+        level.originalImage = pngImporter->image2D(0);
+        CORRADE_VERIFY(level.originalImage);
+        /* Use the first rows of the original images and add a skip to ensure
+           the converter reads the image data properly.
+           We keep originalImage for later because padImageView() doesn't allow
+           non-zero skip to keep it simple, so we can't use imageWithSkip. */
+        level.originalImage1D = padImageView<1>(ImageView2D(*level.originalImage));
+        level.imageWithSkip = copyImageWithSkip<Color4ub>(*level.originalImage1D, {7});
+    }
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+
+    /* Interaction with mip_gen config option is tested in convert2DMipmaps() */
+
+    const auto compressedData = converter->convertToData({*levels[0].imageWithSkip, *levels[1].imageWithSkip, *levels[2].imageWithSkip});
+    CORRADE_VERIFY(compressedData);
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer =
+        _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    /* BasisImageConverter writes 1D images as 2D images with height 1 */
+    CORRADE_COMPARE(importer->image1DCount(), 0);
+    CORRADE_COMPARE(importer->image2DCount(), 1);
+    CORRADE_COMPARE(importer->image2DLevelCount(0), Containers::arraySize(levels));
+
+    for(std::size_t i = 0; i != Containers::arraySize(levels); ++i) {
+        CORRADE_ITERATION("level" << i);
+        levels[i].result = importer->image2D(0, i);
+        CORRADE_VERIFY(levels[i].result);
+        CORRADE_COMPARE(levels[i].result->size().y(), 1);
+    }
+
+    CORRADE_COMPARE_WITH(*levels[0].result, padImageView<2>(ImageView2D(*levels[0].originalImage1D)),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{41.25f, 4.981f}));
+    CORRADE_COMPARE_WITH(*levels[1].result, padImageView<2>(ImageView2D(*levels[1].originalImage1D)),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{30.25f, 6.646f}));
+    CORRADE_COMPARE_WITH(*levels[2].result, padImageView<2>(ImageView2D(*levels[2].originalImage1D)),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{24.0f, 7.4f}));
+}
+
+void BasisImageConverterTest::convert2DR() {
     auto&& data = FormatTransferFunctionData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -418,7 +617,7 @@ void BasisImageConverterTest::r() {
        image data properly. During copy, we only use R channel to retrieve an
        R8 image. */
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub, Math::Vector<1, UnsignedByte>>(
-        *originalImage, {7, 8, 0}, TransferFunctionFormats[data.transferFunction][0]);
+        ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][0]);
 
     const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
@@ -449,7 +648,7 @@ void BasisImageConverterTest::r() {
         (DebugTools::CompareImage{21.0f, 0.968f}));
 }
 
-void BasisImageConverterTest::rg() {
+void BasisImageConverterTest::convert2DRg() {
     auto&& data = FormatTransferFunctionData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -465,7 +664,7 @@ void BasisImageConverterTest::rg() {
        image data properly. During copy, we only use R and G channels to
        retrieve an RG8 image. */
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub, Vector2ub>(
-        *originalImage, {7, 8, 0}, TransferFunctionFormats[data.transferFunction][1]);
+        ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][1]);
 
     const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
@@ -495,7 +694,7 @@ void BasisImageConverterTest::rg() {
         (DebugTools::CompareImage{22.0f, 1.039f}));
 }
 
-void BasisImageConverterTest::rgb() {
+void BasisImageConverterTest::convert2DRgb() {
     auto&& data = FormatTransferFunctionData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -510,7 +709,7 @@ void BasisImageConverterTest::rgb() {
     /* Use the original image and add a skip to ensure the converter reads the
        image data properly */
     const Image2D imageWithSkip = copyImageWithSkip<Color3ub>(
-        *originalImage, {7, 8, 0}, TransferFunctionFormats[data.transferFunction][2]);
+        ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][2]);
 
     const auto compressedData = _converterManager.instantiate("BasisImageConverter")->convertToData(imageWithSkip);
     CORRADE_VERIFY(compressedData);
@@ -532,7 +731,7 @@ void BasisImageConverterTest::rgb() {
         (DebugTools::CompareImageToFile{_manager, 61.0f, 6.622f}));
 }
 
-void BasisImageConverterTest::rgba() {
+void BasisImageConverterTest::convert2DRgba() {
     auto&& data = FormatTransferFunctionData[testCaseInstanceId()];
     setTestCaseDescription(data.name);
 
@@ -547,7 +746,7 @@ void BasisImageConverterTest::rgba() {
     /* Use the original image and add a skip to ensure the converter reads the
        image data properly */
     const Image2D imageWithSkip = copyImageWithSkip<Color4ub>(
-        *originalImage, {7, 8, 0}, TransferFunctionFormats[data.transferFunction][3]);
+        ImageView2D(*originalImage), {7, 8}, TransferFunctionFormats[data.transferFunction][3]);
 
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     const auto compressedData = converter->convertToData(imageWithSkip);
@@ -570,6 +769,225 @@ void BasisImageConverterTest::rgba() {
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
         (DebugTools::CompareImageToFile{_manager, 97.25f, 8.547f}));
+}
+
+void BasisImageConverterTest::convert2DMipmaps() {
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+
+    struct Level {
+        const char* file;
+        Containers::Optional<Image2D> imageWithSkip;
+        Containers::Optional<ImageData2D> result;
+    } levels[3] {
+        {"rgba-63x27.png", {}, {}},
+        {"rgba-31x13.png", {}, {}},
+        {"rgba-15x6.png", {}, {}}
+    };
+
+    for(Level& level: levels) {
+        CORRADE_ITERATION(level.file);
+        CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, level.file)));
+        const auto originalImage = pngImporter->image2D(0);
+        CORRADE_VERIFY(originalImage);
+        /* Use the original images and add a skip to ensure the converter reads
+           the image data properly */
+        level.imageWithSkip = copyImageWithSkip<Color4ub>(ImageView2D(*originalImage), {7, 8});
+    }
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+
+    /* Off by default */
+    CORRADE_COMPARE(converter->configuration().value<bool>("mip_gen"), false);
+    /* Making sure that providing custom levels turns off automatic mip level
+       generation. We only provide an incomplete mip chain so we can tell if
+       basis generated any extra levels beyond that. */
+    converter->configuration().setValue("mip_gen", true);
+
+    std::ostringstream out;
+    Warning redirectWarning{&out};
+
+    const auto compressedData = converter->convertToData({*levels[0].imageWithSkip, *levels[1].imageWithSkip, *levels[2].imageWithSkip});
+    CORRADE_VERIFY(compressedData);
+    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): found user-supplied mip levels, ignoring mip_gen config value\n");
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer =
+        _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    CORRADE_COMPARE(importer->image2DCount(), 1);
+    CORRADE_COMPARE(importer->image2DLevelCount(0), Containers::arraySize(levels));
+
+    for(std::size_t i = 0; i != Containers::arraySize(levels); ++i) {
+        CORRADE_ITERATION("level" << i);
+        levels[i].result = importer->image2D(0, i);
+        CORRADE_VERIFY(levels[i].result);
+    }
+
+    CORRADE_COMPARE_WITH(*levels[0].result,
+        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImageToFile{_manager, 97.25f, 7.882f}));
+    CORRADE_COMPARE_WITH(*levels[1].result,
+        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-31x13.png"),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImageToFile{_manager, 81.0f, 14.33f}));
+    CORRADE_COMPARE_WITH(*levels[2].result,
+        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-15x6.png"),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImageToFile{_manager, 76.25f, 24.5f}));
+}
+
+void BasisImageConverterTest::convert2DArray() {
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png")));
+    const auto originalSlice = pngImporter->image2D(0);
+    CORRADE_VERIFY(originalSlice);
+
+    Containers::Array<char> data{NoInit, originalSlice->data().size()*3};
+    MutableImageView3D originalImage{originalSlice->format(), {originalSlice->size(), 3}, data};
+    Utility::copy(originalSlice->pixels(), originalImage.pixels()[0]);
+    const auto pixels = originalImage.pixels<Color4ub>();
+    for(Int y = 0; y != originalImage.size().y(); ++y) {
+        for(Int x = 0; x != originalImage.size().x(); ++x) {
+            const Color4ub& original = pixels[0][y][x];
+            pixels[1][y][x] = Color4ub{255} - original;
+            pixels[2][y][x] = Math::gather<'b', 'r', 'a', 'g'>(original);
+        }
+    }
+
+    /* Use the built image and add a skip to ensure the converter reads the
+       image data properly */
+    const Image3D imageWithSkip = copyImageWithSkip<Color4ub>(ImageView3D(originalImage), {7, 8, 5});
+
+    std::ostringstream out;
+    Warning redirectWarning{&out};
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData(imageWithSkip);
+    CORRADE_VERIFY(compressedData);
+    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): exporting 3D image as a 2D array image\n");
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer =
+        _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    CORRADE_COMPARE(importer->image3DCount(), 1);
+    CORRADE_COMPARE(importer->textureCount(), 1);
+    const auto texture = importer->texture(0);
+    CORRADE_COMPARE(texture->type(), TextureType::Texture2DArray);
+    const auto image = importer->image3D(0);
+
+    /* CompareImage only supports 2D images, compare each layer individually */
+    CORRADE_COMPARE_WITH(image->pixels<Color4ub>()[0], padImageView<2>(ImageView3D(originalImage), 0),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{97.25f, 7.89f}));
+    CORRADE_COMPARE_WITH(image->pixels<Color4ub>()[1], padImageView<2>(ImageView3D(originalImage), 1),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{97.25f, 7.735f}));
+    CORRADE_COMPARE_WITH(image->pixels<Color4ub>()[2], padImageView<2>(ImageView3D(originalImage), 2),
+        /* There are moderately significant compression artifacts */
+        (DebugTools::CompareImage{96.5f, 6.928f}));
+}
+
+void BasisImageConverterTest::convert2DArrayMipmaps() {
+    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
+
+    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
+
+    struct Level {
+        const char* file;
+        Containers::Optional<Image3D> originalImage;
+        Containers::Optional<Image3D> imageWithSkip;
+        Containers::Optional<ImageData3D> result;
+    } levels[3] {
+        {"rgba-63x27.png", {}, {}},
+        {"rgba-31x13.png", {}, {}},
+        {"rgba-15x6.png", {}, {}}
+    };
+
+    for(Level& level: levels) {
+        CORRADE_ITERATION(level.file);
+        CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, level.file)));
+        const auto originalSlice = pngImporter->image2D(0);
+        CORRADE_VERIFY(originalSlice);
+
+        level.originalImage = Image3D{originalSlice->format(), {originalSlice->size(), 3},
+            Containers::Array<char>{NoInit, originalSlice->data().size()*3}};
+        Utility::copy(originalSlice->pixels(), level.originalImage->pixels()[0]);
+        const auto pixels = level.originalImage->pixels<Color4ub>();
+        for(Int y = 0; y != level.originalImage->size().y(); ++y) {
+            for(Int x = 0; x != level.originalImage->size().x(); ++x) {
+                const Color4ub& original = pixels[0][y][x];
+                pixels[1][y][x] = Color4ub{255} - original;
+                pixels[2][y][x] = Math::gather<'b', 'r', 'a', 'g'>(original);
+            }
+        }
+
+        /* Use the original images and add a skip to ensure the converter reads
+           the image data properly */
+        level.imageWithSkip = copyImageWithSkip<Color4ub>(ImageView3D(*level.originalImage), {7, 8, 5});
+    }
+
+    std::ostringstream out;
+    Warning redirectWarning{&out};
+
+    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
+    const auto compressedData = converter->convertToData({*levels[0].imageWithSkip, *levels[1].imageWithSkip, *levels[2].imageWithSkip});
+    CORRADE_VERIFY(compressedData);
+    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): exporting 3D image as a 2D array image\n");
+
+    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
+        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
+
+    Containers::Pointer<AbstractImporter> importer =
+        _manager.instantiate("BasisImporterRGBA8");
+    CORRADE_VERIFY(importer->openData(compressedData));
+    CORRADE_COMPARE(importer->image3DCount(), 1);
+    CORRADE_COMPARE(importer->image3DLevelCount(0), Containers::arraySize(levels));
+    CORRADE_COMPARE(importer->textureCount(), 1);
+    const auto texture = importer->texture(0);
+    CORRADE_COMPARE(texture->type(), TextureType::Texture2DArray);
+    const auto image = importer->image3D(0);
+
+    for(std::size_t i = 0; i != Containers::arraySize(levels); ++i) {
+        CORRADE_ITERATION("level" << i);
+        levels[i].result = importer->image3D(0, i);
+        CORRADE_VERIFY(levels[i].result);
+    }
+
+    /* CompareImage only supports 2D images, compare each layer individually */
+    for(Int i = 0; i != levels[0].originalImage->size().z(); ++i) {
+        CORRADE_ITERATION("level 0, layer" << i);
+        CORRADE_COMPARE_WITH(levels[0].result->pixels<Color4ub>()[i],
+            padImageView<2>(ImageView3D(*levels[0].originalImage), i),
+            /* There are moderately significant compression artifacts */
+            (DebugTools::CompareImage{97.25f, 7.914f}));
+    }
+    for(Int i = 0; i != levels[0].originalImage->size().z(); ++i) {
+        CORRADE_ITERATION("level 1, layer" << i);
+        CORRADE_COMPARE_WITH(levels[1].result->pixels<Color4ub>()[i],
+            padImageView<2>(ImageView3D(*levels[1].originalImage), i),
+            /* There are moderately significant compression artifacts */
+            (DebugTools::CompareImage{87.0f, 14.453f}));
+    }
+    for(Int i = 0; i != levels[0].originalImage->size().z(); ++i) {
+        CORRADE_ITERATION("level 2, layer" << i);
+        CORRADE_COMPARE_WITH(levels[2].result->pixels<Color4ub>()[i],
+            padImageView<2>(ImageView3D(*levels[2].originalImage), i),
+            /* There are moderately significant compression artifacts */
+            (DebugTools::CompareImage{80.5f, 23.878f}));
+    }
 }
 
 void BasisImageConverterTest::convertToFile() {
@@ -640,8 +1058,7 @@ void BasisImageConverterTest::threads() {
 
     /* Use the original image and add a skip to ensure the converter reads the
        image data properly */
-    const Image2D imageWithSkip = copyImageWithSkip<Color4ub>(
-        *originalImage, {7, 8, 0}, PixelFormat::RGBA8Srgb);
+    const Image2D imageWithSkip = copyImageWithSkip<Color4ub>(ImageView2D(*originalImage), {7, 8});
 
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
     if(data.threads) converter->configuration().setValue("threads", data.threads);
@@ -662,7 +1079,7 @@ void BasisImageConverterTest::threads() {
     CORRADE_COMPARE_WITH(image->pixels<Color4ub>(),
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
-        (DebugTools::CompareImageToFile{_manager, 80.0f, 8.547f}));
+        (DebugTools::CompareImageToFile{_manager, 97.25f, 7.914f}));
 }
 
 void BasisImageConverterTest::ktx() {
@@ -679,8 +1096,7 @@ void BasisImageConverterTest::ktx() {
 
     /* Use the original image and add a skip to ensure the converter reads the
        image data properly */
-    const Image2D imageWithSkip = copyImageWithSkip<Color4ub>(
-        *originalImage, {7, 8, 0}, PixelFormat::RGBA8Unorm);
+    const Image2D imageWithSkip = copyImageWithSkip<Color4ub>(ImageView2D(*originalImage), {7, 8});
 
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisKtxImageConverter");
     converter->configuration().setValue("create_ktx2_file", true);
@@ -712,82 +1128,6 @@ void BasisImageConverterTest::ktx() {
         Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
         /* There are moderately significant compression artifacts */
         (DebugTools::CompareImageToFile{_manager, 97.25f, 9.398f}));
-}
-
-void BasisImageConverterTest::customLevels() {
-    if(_manager.loadState("PngImporter") == PluginManager::LoadState::NotFound)
-        CORRADE_SKIP("PngImporter plugin not found, cannot test contents");
-
-    Containers::Pointer<AbstractImporter> pngImporter = _manager.instantiate("PngImporter");
-    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png")));
-    const auto originalLevel0 = pngImporter->image2D(0);
-    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-31x13.png")));
-    const auto originalLevel1 = pngImporter->image2D(0);
-    CORRADE_VERIFY(pngImporter->openFile(Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-15x6.png")));
-    const auto originalLevel2 = pngImporter->image2D(0);
-    CORRADE_VERIFY(originalLevel0);
-    CORRADE_VERIFY(originalLevel1);
-    CORRADE_VERIFY(originalLevel2);
-
-    /* Use the original images and add a skip to ensure the converter reads the
-       image data properly */
-    const Image2D level0WithSkip = copyImageWithSkip<Color4ub>(
-        *originalLevel0, {7, 8, 0}, PixelFormat::RGBA8Unorm);
-    const Image2D level1WithSkip = copyImageWithSkip<Color4ub>(
-        *originalLevel1, {7, 8, 0}, PixelFormat::RGBA8Unorm);
-    const Image2D level2WithSkip = copyImageWithSkip<Color4ub>(
-        *originalLevel2, {7, 8, 0}, PixelFormat::RGBA8Unorm);
-
-    Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("BasisImageConverter");
-
-    /* Off by default */
-    CORRADE_COMPARE(converter->configuration().value<bool>("mip_gen"), false);
-    /* Making sure that providing custom levels turns off automatic mip level
-       generation. We only provide an incomplete mip chain so we can tell if
-       basis generated any extra levels beyond that. */
-    converter->configuration().setValue("mip_gen", true);
-
-    std::ostringstream out;
-    Warning redirectWarning{&out};
-
-    const auto compressedData = converter->convertToData({level0WithSkip, level1WithSkip, level2WithSkip});
-    CORRADE_VERIFY(compressedData);
-    CORRADE_COMPARE(out.str(), "Trade::BasisImageConverter::convertToData(): found user-supplied mip levels, ignoring mip_gen config value\n");
-
-    if(_manager.loadState("BasisImporter") == PluginManager::LoadState::NotFound)
-        CORRADE_SKIP("BasisImporter plugin not found, cannot test");
-
-    Containers::Pointer<AbstractImporter> importer =
-        _manager.instantiate("BasisImporterRGBA8");
-    CORRADE_VERIFY(importer->openData(compressedData));
-    CORRADE_COMPARE(importer->image2DCount(), 1);
-    CORRADE_COMPARE(importer->image2DLevelCount(0), 3);
-
-    Containers::Optional<Trade::ImageData2D> level0 = importer->image2D(0, 0);
-    Containers::Optional<Trade::ImageData2D> level1 = importer->image2D(0, 1);
-    Containers::Optional<Trade::ImageData2D> level2 = importer->image2D(0, 2);
-    CORRADE_VERIFY(level0);
-    CORRADE_VERIFY(level1);
-    CORRADE_VERIFY(level2);
-
-    CORRADE_COMPARE(level0->size(), (Vector2i{63, 27}));
-    CORRADE_COMPARE(level1->size(), (Vector2i{31, 13}));
-    CORRADE_COMPARE(level2->size(), (Vector2i{15, 6}));
-
-    /* Basis can only load RGBA8 uncompressed data, which corresponds to RGB1
-       from our RGB8 image data. */
-    CORRADE_COMPARE_WITH(level0->pixels<Color4ub>(),
-        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-63x27.png"),
-        /* There are moderately significant compression artifacts */
-        (DebugTools::CompareImageToFile{_manager, 97.25f, 7.882f}));
-    CORRADE_COMPARE_WITH(level1->pixels<Color4ub>(),
-        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-31x13.png"),
-        /* There are moderately significant compression artifacts */
-        (DebugTools::CompareImageToFile{_manager, 81.0f, 14.33f}));
-    CORRADE_COMPARE_WITH(level2->pixels<Color4ub>(),
-        Utility::Directory::join(BASISIMPORTER_TEST_DIR, "rgba-15x6.png"),
-        /* There are moderately significant compression artifacts */
-        (DebugTools::CompareImageToFile{_manager, 76.25f, 24.5f}));
 }
 
 void BasisImageConverterTest::swizzle() {

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
@@ -593,7 +593,7 @@ Containers::Optional<ImageData<dimensions>> BasisImporter::doImage(const Unsigne
             if(_state->ktx2Transcoder) {
                 const UnsignedInt currentLayer = id + l;
                 if(!_state->ktx2Transcoder->transcode_image_level(level, currentLayer, f, dest.data() + offset, outputSizeInBlocksOrPixels, format, flags, rowStride, outputRowsInPixels)) {
-                    Error{} << "Trade::BasisImporter::image2D(): transcoding failed";
+                    Error{} << prefix << "transcoding failed";
                     return Containers::NullOpt;
                 }
             } else
@@ -601,7 +601,7 @@ Containers::Optional<ImageData<dimensions>> BasisImporter::doImage(const Unsigne
             {
                 const UnsignedInt currentId = id + (l*numFaces + f);
                 if(!_state->basisTranscoder->transcode_image_level(_state->in.data(), _state->in.size(), currentId, level, dest.data() + offset, outputSizeInBlocksOrPixels, format, flags, rowStride, nullptr, outputRowsInPixels)) {
-                    Error{} << "Trade::BasisImporter::image2D(): transcoding failed";
+                    Error{} << prefix << "transcoding failed";
                     return Containers::NullOpt;
                 }
             }

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.cpp
@@ -464,8 +464,7 @@ void BasisImporter::doOpenData(Containers::Array<char>&& data, DataFlags dataFla
     _state = std::move(state);
 }
 
-template<UnsignedInt dimensions>
-Containers::Optional<ImageData<dimensions>> BasisImporter::doImage(const UnsignedInt id, const UnsignedInt level) {
+template<UnsignedInt dimensions> Containers::Optional<ImageData<dimensions>> BasisImporter::doImage(const UnsignedInt id, const UnsignedInt level) {
     static_assert(dimensions >= 2 && dimensions <= 3, "Only 2D and 3D images are supported");
     constexpr const char* prefixes[2]{"Trade::BasisImporter::image2D():", "Trade::BasisImporter::image3D():"};
     constexpr const char* prefix = prefixes[dimensions - 2];

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.h
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.h
@@ -390,8 +390,7 @@ class MAGNUM_BASISIMPORTER_EXPORT BasisImporter: public AbstractImporter {
         struct State;
         Containers::Pointer<State> _state;
 
-        template<UnsignedInt dimensions>
-        Containers::Optional<ImageData<dimensions>> doImage(UnsignedInt id, UnsignedInt level);
+        template<UnsignedInt dimensions> Containers::Optional<ImageData<dimensions>> doImage(UnsignedInt id, UnsignedInt level);
 };
 
 }}

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.h
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.h
@@ -376,6 +376,8 @@ class MAGNUM_BASISIMPORTER_EXPORT BasisImporter: public AbstractImporter {
         MAGNUM_BASISIMPORTER_LOCAL void doClose() override;
         MAGNUM_BASISIMPORTER_LOCAL void doOpenData(Containers::Array<char>&& data, DataFlags dataFlags) override;
 
+        template<UnsignedInt dimensions> MAGNUM_BASISIMPORTER_LOCAL Containers::Optional<ImageData<dimensions>> doImage(UnsignedInt id, UnsignedInt level);
+
         MAGNUM_BASISIMPORTER_LOCAL UnsignedInt doImage2DCount() const override;
         MAGNUM_BASISIMPORTER_LOCAL UnsignedInt doImage2DLevelCount(UnsignedInt id) override;
         MAGNUM_BASISIMPORTER_LOCAL Containers::Optional<ImageData2D> doImage2D(UnsignedInt id, UnsignedInt level) override;
@@ -389,8 +391,6 @@ class MAGNUM_BASISIMPORTER_EXPORT BasisImporter: public AbstractImporter {
 
         struct State;
         Containers::Pointer<State> _state;
-
-        template<UnsignedInt dimensions> Containers::Optional<ImageData<dimensions>> doImage(UnsignedInt id, UnsignedInt level);
 };
 
 }}

--- a/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.cpp
+++ b/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.cpp
@@ -523,8 +523,7 @@ Containers::Pair<UnsignedInt, UnsignedInt> channelMapping(Implementation::VkForm
     CORRADE_ASSERT_UNREACHABLE("channelMapping(): invalid format suffix" << UnsignedInt(suffix), {}); /* LCOV_EXCL_LINE */
 }
 
-template<typename Format>
-Containers::Array<char> fillDataFormatDescriptor(Format format, Implementation::VkFormatSuffix suffix) {
+template<typename Format> Containers::Array<char> fillDataFormatDescriptor(Format format, Implementation::VkFormatSuffix suffix) {
     const auto sampleData = samples(format);
     CORRADE_INTERNAL_ASSERT(!sampleData.second().empty());
 
@@ -668,15 +667,13 @@ UnsignedInt leastCommonMultiple(UnsignedInt a, UnsignedInt b) {
     return product/gcd;
 }
 
-template<UnsignedInt dimensions>
-void copyPixels(const BasicImageView<dimensions>& image, Containers::ArrayView<char> pixels) {
+template<UnsignedInt dimensions> void copyPixels(const BasicImageView<dimensions>& image, Containers::ArrayView<char> pixels) {
     /* Copy the pixels into output, dropping padding (if any) */
     const Containers::StridedArrayView<dimensions + 1, const char> srcPixels = image.pixels();
     Utility::copy(srcPixels, Containers::StridedArrayView<dimensions + 1, char>{pixels, srcPixels.size()});
 }
 
-template<UnsignedInt dimensions>
-void copyPixels(const BasicCompressedImageView<dimensions>& image, Containers::ArrayView<char> pixels) {
+template<UnsignedInt dimensions> void copyPixels(const BasicCompressedImageView<dimensions>& image, Containers::ArrayView<char> pixels) {
     /** @todo Support CompressedPixelStorage::skip */
     CORRADE_ASSERT(image.storage() == CompressedPixelStorage{}, "Trade::KtxImageConverter::convertToData(): non-default compressed storage is not supported", );
     Utility::copy(image.data().prefix(pixels.size()), pixels);
@@ -716,8 +713,7 @@ constexpr Containers::StringView ValidOrientations[3]{"rl"_s, "du"_s, "io"_s};
 /* Using a template template parameter to deduce the image dimensions while
    matching both ImageView and CompressedImageView. Matching on the ImageView
    typedefs doesn't work, so we need the extra parameter of BasicImageView. */
-template<UnsignedInt dimensions, template<UnsignedInt, typename> class View>
-Containers::Array<char> convertLevels(Containers::ArrayView<const View<dimensions, const char>> imageLevels, const Utility::ConfigurationGroup& configuration) {
+template<UnsignedInt dimensions, template<UnsignedInt, typename> class View> Containers::Array<char> convertLevels(Containers::ArrayView<const View<dimensions, const char>> imageLevels, const Utility::ConfigurationGroup& configuration) {
     const auto format = imageLevels.front().format();
     if(isFormatImplementationSpecific(format)) {
         Error{} << "Trade::KtxImageConverter::convertToData(): implementation-specific formats are not supported";

--- a/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.cpp
+++ b/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.cpp
@@ -515,9 +515,9 @@ Containers::Pair<UnsignedInt, UnsignedInt> channelMapping(Implementation::VkForm
         case Implementation::VkFormatSuffix::SINT:
             return {~0u, 1u};
         case Implementation::VkFormatSuffix::UFLOAT:
-            return {Corrade::Utility::bitCast<UnsignedInt>(0.0f), Corrade::Utility::bitCast<UnsignedInt>(1.0f)};
+            return {Utility::bitCast<UnsignedInt>(0.0f), Utility::bitCast<UnsignedInt>(1.0f)};
         case Implementation::VkFormatSuffix::SFLOAT:
-            return {Corrade::Utility::bitCast<UnsignedInt>(-1.0f), Corrade::Utility::bitCast<UnsignedInt>(1.0f)};
+            return {Utility::bitCast<UnsignedInt>(-1.0f), Utility::bitCast<UnsignedInt>(1.0f)};
     }
 
     CORRADE_ASSERT_UNREACHABLE("channelMapping(): invalid format suffix" << UnsignedInt(suffix), {}); /* LCOV_EXCL_LINE */
@@ -717,7 +717,7 @@ constexpr Containers::StringView ValidOrientations[3]{"rl"_s, "du"_s, "io"_s};
    matching both ImageView and CompressedImageView. Matching on the ImageView
    typedefs doesn't work, so we need the extra parameter of BasicImageView. */
 template<UnsignedInt dimensions, template<UnsignedInt, typename> class View>
-Containers::Array<char> convertLevels(Containers::ArrayView<const View<dimensions, const char>> imageLevels, const Corrade::Utility::ConfigurationGroup& configuration) {
+Containers::Array<char> convertLevels(Containers::ArrayView<const View<dimensions, const char>> imageLevels, const Utility::ConfigurationGroup& configuration) {
     const auto format = imageLevels.front().format();
     if(isFormatImplementationSpecific(format)) {
         Error{} << "Trade::KtxImageConverter::convertToData(): implementation-specific formats are not supported";

--- a/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.h
+++ b/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.h
@@ -104,18 +104,27 @@ The following formats can be written:
 -   all formats in @ref PixelFormat
 -   all formats in @ref CompressedPixelFormat, except for 3D ASTC formats
 
-@subsection Trade-KtxImageConverter-behavior-cube-array Cube map and array images
+@subsection Trade-KtxImageConverter-behavior-types Image types
 
-Cube map and array images can be written but there is currently no way to mark
-them properly in the metadata. Exported files will be 3D images with cube map
-faces and array layers exposed as depth slices.
+Cube map images can be written but there is currently no way to mark them
+properly in the metadata. Exported files will be 3D images with faces exposed
+as depth slices.
+
+Array images will be written as images with one extra dimension for the array
+layers. For example, a 2x3 2D array image with 4 layers will result in a 3D
+image with size 2x3x4.
 
 @subsection Trade-KtxImageConverter-behavior-multilevel Multilevel images
 
 All image types can be saved with multiple levels by using the list
 variants of @ref convertToFile() / @ref convertToData(). Largest level is
-expected to be first, with each following level having width and height divided
-by two, rounded down. Incomplete mip chains are supported.
+expected to be first, with each following level having width, height and depth
+divided by two, rounded down. Incomplete mip chains are supported.
+
+Due to the way @ref Trade-KtxImageConverter-behavior-types "non-trivial image types"
+are handled, the level sizes are always expected to match the resulting image
+type. This means that array images with multiple levels can currently not be
+exported and produce a level size mismatch error.
 
 @subsection Trade-KtxImageConverter-behavior-supercompression Supercompression
 

--- a/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.h
+++ b/src/MagnumPlugins/KtxImageConverter/KtxImageConverter.h
@@ -148,15 +148,15 @@ class MAGNUM_KTXIMAGECONVERTER_EXPORT KtxImageConverter: public AbstractImageCon
         explicit KtxImageConverter(PluginManager::AbstractManager& manager, const std::string& plugin);
 
     private:
-        ImageConverterFeatures MAGNUM_KTXIMAGECONVERTER_LOCAL doFeatures() const override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL ImageConverterFeatures doFeatures() const override;
 
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const ImageView1D> imageLevels) override;
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView1D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView2D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const ImageView3D> imageLevels) override;
 
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const CompressedImageView1D> imageLevels) override;
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const CompressedImageView2D> imageLevels) override;
-        Containers::Array<char> MAGNUM_KTXIMAGECONVERTER_LOCAL doConvertToData(Containers::ArrayView<const CompressedImageView3D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const CompressedImageView1D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const CompressedImageView2D> imageLevels) override;
+        MAGNUM_KTXIMAGECONVERTER_LOCAL Containers::Array<char> doConvertToData(Containers::ArrayView<const CompressedImageView3D> imageLevels) override;
 };
 
 }}

--- a/src/MagnumPlugins/KtxImageConverter/Test/KtxImageConverterTest.cpp
+++ b/src/MagnumPlugins/KtxImageConverter/Test/KtxImageConverterTest.cpp
@@ -184,10 +184,30 @@ constexpr UnsignedLong PatternDepth32FStencil8UIData[4*3]{
     0, FullL,     0, FullL
 };
 
-const char* WriterToktx = "toktx v4.0.0~6 / libktx v4.0.0~5";
-const char* WriterPVRTexTool = "PVRTexLib v5.1.0";
+constexpr const char* WriterToktx = "toktx v4.0.0~6 / libktx v4.0.0~5";
+constexpr const char* WriterPVRTexTool = "PVRTexLib v5.1.0";
 
-const struct {
+constexpr struct {
+    const char* name;
+    const Vector3i size;
+    const char* message;
+} TooManyLevelsData[]{
+    {"1D", {1, 0, 0}, "there can be only 1 levels with base image size Vector(1) but got 2"},
+    {"2D", {1, 1, 0}, "there can be only 1 levels with base image size Vector(1, 1) but got 2"},
+    {"3D", {1, 1, 1}, "there can be only 1 levels with base image size Vector(1, 1, 1) but got 2"}
+};
+
+constexpr struct {
+    const char* name;
+    const Vector3i sizes[2];
+    const char* message;
+} LevelWrongSizeData[]{
+    {"1D", {{4, 0, 0}, {3, 0, 0}}, "expected size Vector(2) for level 1 but got Vector(3)"},
+    {"2D", {{4, 5, 0}, {2, 1, 0}}, "expected size Vector(2, 2) for level 1 but got Vector(2, 1)"},
+    {"3D", {{4, 5, 3}, {2, 2, 2}}, "expected size Vector(2, 2, 1) for level 1 but got Vector(2, 2, 2)"}
+};
+
+constexpr struct {
     const char* name;
     const char* file;
     const CompressedPixelFormat format;
@@ -197,7 +217,7 @@ const struct {
     {"ETC2", "1d-compressed-etc2.ktx2", CompressedPixelFormat::Etc2RGB8Srgb, {7}}
 };
 
-const struct {
+constexpr struct {
     const char* name;
     const char* file;
     const CompressedPixelFormat format;
@@ -234,7 +254,7 @@ const struct {
         Containers::arrayCast<const char>(PatternDepth32FStencil8UIData), true}
 };
 
-const struct {
+constexpr struct {
     const char* name;
     const CompressedPixelFormat inputFormat;
     const CompressedPixelFormat outputFormat;
@@ -245,7 +265,7 @@ const struct {
     {"4bppSrgb", CompressedPixelFormat::PvrtcRGB4bppSrgb, CompressedPixelFormat::PvrtcRGBA4bppSrgb},
 };
 
-const struct {
+constexpr struct {
     const char* name;
     const char* value;
     const char* message;
@@ -255,7 +275,7 @@ const struct {
     {"invalid order", "rid", "invalid character in orientation, expected d or u but got i"},
 };
 
-const struct {
+constexpr struct {
     const char* name;
     const char* value;
     const char* message;
@@ -299,12 +319,15 @@ KtxImageConverterTest::KtxImageConverterTest() {
               &KtxImageConverterTest::dataFormatDescriptor,
               &KtxImageConverterTest::dataFormatDescriptorCompressed,
 
-              &KtxImageConverterTest::pixelStorage,
+              &KtxImageConverterTest::pixelStorage});
 
-              &KtxImageConverterTest::tooManyLevels,
-              &KtxImageConverterTest::levelWrongSize,
+    addInstancedTests({&KtxImageConverterTest::tooManyLevels},
+        Containers::arraySize(TooManyLevelsData));
 
-              &KtxImageConverterTest::convert1D,
+    addInstancedTests({&KtxImageConverterTest::levelWrongSize},
+        Containers::arraySize(LevelWrongSizeData));
+
+    addTests({&KtxImageConverterTest::convert1D,
               &KtxImageConverterTest::convert1DMipmaps});
 
     addInstancedTests({&KtxImageConverterTest::convert1DCompressed},
@@ -580,33 +603,69 @@ void KtxImageConverterTest::pixelStorage() {
 }
 
 void KtxImageConverterTest::tooManyLevels() {
+    auto&& data = TooManyLevelsData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("KtxImageConverter");
 
     const UnsignedByte bytes[4]{};
+    CORRADE_INTERNAL_ASSERT(Math::max(Vector3ui{data.size}, 1u).product()*4u <= Containers::arraySize(bytes));
+
+    const UnsignedInt dimensions = Math::min(Vector3ui{data.size}, 1u).sum();
 
     std::ostringstream out;
     Error redirectError{&out};
-    CORRADE_VERIFY(!converter->convertToData({
-        ImageView2D{PixelFormat::RGB8Unorm, {1, 1}, bytes},
-        ImageView2D{PixelFormat::RGB8Unorm, {1, 1}, bytes}
-    }));
-    CORRADE_COMPARE(out.str(),
-        "Trade::KtxImageConverter::convertToData(): there can be only 1 levels with base image size Vector(1, 1) but got 2\n");
+    if(dimensions == 1) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView1D{PixelFormat::RGBA8Unorm, data.size.x(), bytes},
+            ImageView1D{PixelFormat::RGBA8Unorm, data.size.x(), bytes}
+        }));
+    } else if(dimensions == 2) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView2D{PixelFormat::RGBA8Unorm, data.size.xy(), bytes},
+            ImageView2D{PixelFormat::RGBA8Unorm, data.size.xy(), bytes}
+        }));
+    } else if(dimensions == 3) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView3D{PixelFormat::RGBA8Unorm, data.size, bytes},
+            ImageView3D{PixelFormat::RGBA8Unorm, data.size, bytes}
+        }));
+    }
+
+    CORRADE_COMPARE(out.str(), Utility::formatString("Trade::KtxImageConverter::convertToData(): {}\n", data.message));
 }
 
 void KtxImageConverterTest::levelWrongSize() {
+    auto&& data = LevelWrongSizeData[testCaseInstanceId()];
+    setTestCaseDescription(data.name);
+
     Containers::Pointer<AbstractImageConverter> converter = _converterManager.instantiate("KtxImageConverter");
 
-    const UnsignedByte bytes[16]{};
+    const UnsignedByte bytes[256]{};
+    CORRADE_INTERNAL_ASSERT(Math::max(Vector3ui{data.sizes[0]}, 1u).product()*4u <= Containers::arraySize(bytes));
+
+    const UnsignedInt dimensions = Math::min(Vector3ui{data.sizes[0]}, 1u).sum();
 
     std::ostringstream out;
     Error redirectError{&out};
-    CORRADE_VERIFY(!converter->convertToData({
-        ImageView2D{PixelFormat::RGB8Unorm, {2, 2}, bytes},
-        ImageView2D{PixelFormat::RGB8Unorm, {2, 1}, bytes}
-    }));
-    CORRADE_COMPARE(out.str(),
-        "Trade::KtxImageConverter::convertToData(): expected size Vector(1, 1) for level 1 but got Vector(2, 1)\n");
+    if(dimensions == 1) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView1D{PixelFormat::RGBA8Unorm, data.sizes[0].x(), bytes},
+            ImageView1D{PixelFormat::RGBA8Unorm, data.sizes[1].x(), bytes}
+        }));
+    } else if(dimensions == 2) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView2D{PixelFormat::RGBA8Unorm, data.sizes[0].xy(), bytes},
+            ImageView2D{PixelFormat::RGBA8Unorm, data.sizes[1].xy(), bytes}
+        }));
+    } else if(dimensions == 3) {
+        CORRADE_VERIFY(!converter->convertToData({
+            ImageView3D{PixelFormat::RGBA8Unorm, data.sizes[0], bytes},
+            ImageView3D{PixelFormat::RGBA8Unorm, data.sizes[1], bytes}
+        }));
+    }
+
+    CORRADE_COMPARE(out.str(), Utility::formatString("Trade::KtxImageConverter::convertToData(): {}\n", data.message));
 }
 
 void KtxImageConverterTest::convert1D() {

--- a/src/MagnumPlugins/KtxImporter/KtxImporter.cpp
+++ b/src/MagnumPlugins/KtxImporter/KtxImporter.cpp
@@ -806,8 +806,7 @@ void KtxImporter::doOpenData(Containers::Array<char>&& data, DataFlags dataFlags
     _f = std::move(f);
 }
 
-template<UnsignedInt dimensions>
-ImageData<dimensions> KtxImporter::doImage(UnsignedInt id, UnsignedInt level) {
+template<UnsignedInt dimensions> ImageData<dimensions> KtxImporter::doImage(UnsignedInt id, UnsignedInt level) {
     const File::LevelData& levelData = _f->imageData[id][level];
     const auto size = Math::Vector<dimensions, Int>::pad(levelData.size);
     Containers::Array<char> data{NoInit, levelData.data.size()};

--- a/src/MagnumPlugins/KtxImporter/KtxImporter.h
+++ b/src/MagnumPlugins/KtxImporter/KtxImporter.h
@@ -199,6 +199,8 @@ class MAGNUM_KTXIMPORTER_EXPORT KtxImporter: public AbstractImporter {
         MAGNUM_KTXIMPORTER_LOCAL void doClose() override;
         MAGNUM_KTXIMPORTER_LOCAL void doOpenData(Containers::Array<char>&& data, DataFlags dataFlags) override;
 
+        template<UnsignedInt dimensions> MAGNUM_KTXIMPORTER_LOCAL ImageData<dimensions> doImage(UnsignedInt id, UnsignedInt level);
+
         MAGNUM_KTXIMPORTER_LOCAL UnsignedInt doImage1DCount() const override;
         MAGNUM_KTXIMPORTER_LOCAL UnsignedInt doImage1DLevelCount(UnsignedInt id) override;
         MAGNUM_KTXIMPORTER_LOCAL Containers::Optional<ImageData1D> doImage1D(UnsignedInt id, UnsignedInt level) override;
@@ -214,12 +216,9 @@ class MAGNUM_KTXIMPORTER_EXPORT KtxImporter: public AbstractImporter {
         MAGNUM_KTXIMPORTER_LOCAL UnsignedInt doTextureCount() const override;
         MAGNUM_KTXIMPORTER_LOCAL Containers::Optional<TextureData> doTexture(UnsignedInt id) override;
 
-    private:
         struct File;
         Containers::Pointer<File> _f;
         Containers::Pointer<AbstractImporter> _basisImporter;
-
-        template<UnsignedInt dimensions> ImageData<dimensions> doImage(UnsignedInt id, UnsignedInt level);
 };
 
 }}

--- a/src/MagnumPlugins/KtxImporter/KtxImporter.h
+++ b/src/MagnumPlugins/KtxImporter/KtxImporter.h
@@ -219,8 +219,7 @@ class MAGNUM_KTXIMPORTER_EXPORT KtxImporter: public AbstractImporter {
         Containers::Pointer<File> _f;
         Containers::Pointer<AbstractImporter> _basisImporter;
 
-        template<UnsignedInt dimensions>
-        ImageData<dimensions> doImage(UnsignedInt id, UnsignedInt level);
+        template<UnsignedInt dimensions> ImageData<dimensions> doImage(UnsignedInt id, UnsignedInt level);
 };
 
 }}


### PR DESCRIPTION
This adds missing functionality to `BasisImageConverter` to allow 2D array images.

The rationale for treating `ImageView3D` as a 2D array image is the same reason all 3D images in `BasisImporter` are imported as 2D array images. The tl;dr is that basis_universal assumes mip levels are 2D and KTX2 export doesn't support 3D images either.

There are minor fixes for `KtxImageConverter` in the commit list too, noticed those while cross-referencing code and docs.