### PR TITLE
modules: Fix FindWebP.cmake for windows

### DIFF
--- a/modules/FindWebP.cmake
+++ b/modules/FindWebP.cmake
@@ -39,7 +39,7 @@
 #
 
 # Library
-find_library(WebP_LIBRARY NAMES webp)
+find_library(WebP_LIBRARY NAMES webp libwebp)
 
 # Include dir
 find_path(WebP_INCLUDE_DIR


### PR DESCRIPTION
Hi @mosra !


This is a very simple one, the precompiled binaries on windows are named `libwebp.lib` and similar, and on Windows, `NAMES webp` is therefore not enough, since windows has empty `CMAKE_STATIC_LIBRARY_PREFIX`.

Best,
Jonathan