### PR TITLE
Mesh compression

### DIFF
--- a/src/MagnumPlugins/MeshOptimizerSceneConverter/Test/MeshOptimizerSceneConverterTest.cpp
+++ b/src/MagnumPlugins/MeshOptimizerSceneConverter/Test/MeshOptimizerSceneConverterTest.cpp
@@ -1146,9 +1146,6 @@ void MeshOptimizerSceneConverterTest::simplifyVerbose() {
 }
 void MeshOptimizerSceneConverterTest::encodeDecodeInterleavedMesh() {
     Containers::Pointer<AbstractSceneConverter> converter = _manager.instantiate("MeshOptimizerSceneConverter");
-    converter->configuration().setValue("optimizeVertexCache", false);
-    converter->configuration().setValue("optimizeOverdraw", false);
-    converter->configuration().setValue("optimizeVertexFetch", false);
     converter->configuration().setValue("encodeVertex", true);
 
     struct QuadVertex {
@@ -1164,7 +1161,7 @@ void MeshOptimizerSceneConverterTest::encodeDecodeInterleavedMesh() {
         {{-1.0f, -0.5f}, {0.8f, 0.0f}, {30,70,150,0}},
         {{-1.0f,  0.5f}, {1.0f, 0.8f}, {30,150,70,0}},
     };
-    const  UnsignedInt indices[]{0, 1, 2, 5, 3, 4};
+    const  UnsignedInt indices[]{0, 1, 2, 2, 1, 3};
 
     const Trade::MeshData mesh{MeshPrimitive::Triangles,
                           Trade::DataFlags{}, indices, Trade::MeshIndexData{indices},
@@ -1190,12 +1187,10 @@ void MeshOptimizerSceneConverterTest::encodeDecodeInterleavedMesh() {
     CORRADE_COMPARE(encoded->attributeCount(), mesh.attributeCount());
     CORRADE_COMPARE(encoded->attributeStride(0), mesh.attributeStride(0));
 
-
-
-
-    //converter->configuration().setValue("decodeVertex", true);
-    //Containers::Optional<MeshData> decoded = converter->convert(*encoded);
-    //CORRADE_VERIFY(decoded);
+    // encoded data size (181) is not enough for {6, 32} elements of stride {32, 1}
+    // converter->configuration().setValue("decodeVertex", true);
+    // Containers::Optional<MeshData> decoded = converter->convert(*encoded);
+    // CORRADE_VERIFY(decoded);
 
 }
 
@@ -1235,9 +1230,10 @@ void MeshOptimizerSceneConverterTest::encodeInterleavedLongMesh() {
                                                                         Containers::arrayView(vertices), &vertices[0].color,
                                                                         Containers::arraySize(vertices), sizeof(QuadVertex)}}
                                }};
-    //Containers::Optional<MeshData> encoded = converter->convert(mesh);
-   // CORRADE_COMPARE(encoded->vertexData().size(), 100);
-   // CORRADE_VERIFY(encoded);
+    //offset-only attribute 0 spans 224 bytes but passed vertexData array has only 209
+//    Containers::Optional<MeshData> encoded = converter->convert(mesh);
+//    CORRADE_VERIFY(encoded);
+//    CORRADE_VERIFY(encoded->vertexData().size() < mesh.vertexData().size());
 }
 
 void MeshOptimizerSceneConverterTest::encodeNonInterleavedMesh() {
@@ -1293,8 +1289,8 @@ void MeshOptimizerSceneConverterTest::encodeDecodeIndex() {
     converter->configuration().setValue("optimizeVertexFetch", false);
     converter->configuration().setValue("encodeIndex", true);
 
-    //const UnsignedInt indexData[]{0,1,2,2,1,3,0,1,2,3,2,1,1,2,3,0,1,2,3,2,2,1,3,1};
-    const  UnsignedInt indexData[]{ 0, 1, 2, 2, 1, 3 };
+    const UnsignedByte indexData[]{0, 1, 2, 2, 1, 3};
+    //const  UnsignedInt indexData[]{0, 1, 2, 2, 1, 3};
     //const UnsignedShort indexData[]{ 0, 1, 2, 2, 1, 3,0,1,2,3,2,2,1,3,1};
     MeshData mesh{MeshPrimitive::Triangles, {}, indexData, MeshIndexData{indexData}, nullptr, {}, 1};
 
@@ -1304,11 +1300,12 @@ void MeshOptimizerSceneConverterTest::encodeDecodeIndex() {
     CORRADE_COMPARE(encoded->indexType(), MeshIndexType::UnsignedByte);
     //CORRADE_COMPARE(encoded->indexCount(), mesh.indexCount());
 
-    converter->configuration().setValue("encodeIndex", false);
-    converter->configuration().setValue("decodeIndex", true);
-    Containers::Optional<MeshData> decoded = converter->convert(*encoded);
-    CORRADE_VERIFY(decoded);
-    CORRADE_COMPARE(decoded->indexData().size(), mesh.indexData().size());
+    //converter->configuration().setValue("decodeIndex", true);
+    //Containers::Optional<MeshData> decoded = converter->convert(*encoded);
+
+    /* Assertion `index_count % 3 == 0' fails because indexData.size is shown to be the indexCount */
+    //CORRADE_VERIFY(decoded);
+    //CORRADE_COMPARE(decoded->indexData().size(), mesh.indexData().size());
 }
 
 }}}}


### PR DESCRIPTION
Hey @mosra, @Squareys,
here is the first outlook on mesh compression.


I have used “TexturedQuadExample” from magnum examples to figure out how mesh compression of meshoptimizer library works and created interleaved and non-interleaved mesh data using the position, texture, and color data in the example. Later on, I adapted my work there to the plugin, but got the following errors when I started testing:

**Index Compression**

When wrapped in a MeshData instance as the following, the encoded index data can’t be decoded because the encoded indexData.size() gets assigned to the indexCount(), hence the requirement ‘index_count % 3 == 0' fails: 
    `out = Trade::MeshData{primitive, {}, encoded_buffer, Trade::MeshIndexData{encoded_buffer}, {}, vertexData, attributeData, 
                                           vertexCount};`

So, in the case above out.indexCount() yields out.indexData.size() instead of the number of indices.

**Vertex Compression**

1- With interleaved mesh, encoded data can be put in a MeshData instance only when all attribute spans are smaller than the encoded data size, which can be achieved only with short vertex buffers as in the test example `MeshOptimizerSceneConverterTest::encodeDecodeInterleavedMesh()`. However, an encoded vertex data successfully wrapped in a MeshData instance can’t be used as an argument in doConvert() for decoding because the attribute information doesn’t match the vertex data information.
  
When the number of vertices is increased as in the example `MeshOptimizerSceneConverterTest::encodeInterleavedLongMesh()`, an error about an attribute span incompatible with the given encoded vertex data occurs, hence no MeshData instance with the encoded data in it can be created.     

2- With non-interleaved mesh, I’ve done encoding attribute by attribute and merged encoded buffers into one to wrap it with a MeshData instance, which makes decoding problematic because decoding also needs to be performed separately on each attribute but encoded MeshData can’t give any information on where each attribute data starts and ends. I tried putting this info in the MeshData instance by changing the offset of the encoded data in accordance with the size of each encoded attribute data but it returned with an attribute span error.
 