### PR TITLE
Rework libpng error handling to catch version mismatch errors as well

### DIFF
--- a/doc/changelog-plugins.dox
+++ b/doc/changelog-plugins.dox
@@ -264,7 +264,8 @@ namespace Magnum {
 -   @relativeref{Trade,PngImporter} and @relativeref{Trade,PngImageConverter}
     no longer asserts if the patch version of libpng changed, such as when a
     system package was upgraded from 1.6.37 to 1.6.38. If the major or minor
-    version changes, it's still an assert.
+    version changes, it's now a runtime error, produced by libpng itself,
+    instead of an assert.
 
 @subsection changelog-plugins-latest-deprecated Deprecated APIs
 

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -2,32 +2,32 @@ clone_depth: 1
 
 environment:
   matrix:
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    APPVEYOR_JOB_NAME: windows-msvc2015
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    APPVEYOR_JOB_NAME: windows-msvc2017
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    APPVEYOR_JOB_NAME: windows-msvc2019
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    APPVEYOR_JOB_NAME: windows-msvc2022
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    APPVEYOR_JOB_NAME: windows-static-msvc2019
-    BUILD_STATIC: ON
-  - TARGET: desktop
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    APPVEYOR_JOB_NAME: windows-static-msvc2022
-    BUILD_STATIC: ON
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #   APPVEYOR_JOB_NAME: windows-msvc2015
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #   APPVEYOR_JOB_NAME: windows-msvc2017
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  #   APPVEYOR_JOB_NAME: windows-msvc2019
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  #   APPVEYOR_JOB_NAME: windows-msvc2022
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  #   APPVEYOR_JOB_NAME: windows-static-msvc2019
+  #   BUILD_STATIC: ON
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  #   APPVEYOR_JOB_NAME: windows-static-msvc2022
+  #   BUILD_STATIC: ON
   - TARGET: desktop
     COMPILER: msvc-clang
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -36,29 +36,29 @@ environment:
     COMPILER: msvc-clang
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
     APPVEYOR_JOB_NAME: windows-msvc2022-clang
-  - TARGET: desktop
-    COMPILER: msvc
-    # Same reasoning as in Corrade for /EHsc
-    COMPILER_EXTRA: -DCMAKE_CXX_FLAGS="/permissive- /EHsc" -DMSVC_COMPATIBILITY=OFF
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    APPVEYOR_JOB_NAME: windows-conforming-msvc2019
-  - TARGET: desktop
-    COMPILER: msvc
-    # Not playing with fire and using /EHsc on 2022 as well
-    COMPILER_EXTRA: -DCMAKE_CXX_FLAGS="/permissive- /EHsc" -DMSVC_COMPATIBILITY=OFF
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-    APPVEYOR_JOB_NAME: windows-conforming-msvc2022
-  - TARGET: desktop
-    COMPILER: mingw
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    APPVEYOR_JOB_NAME: windows-mingw
-  - TARGET: rt
-    # This actually isn't needed anywhere, but without this the %COMPILE:~0,4%
-    # expressions cause a "The syntax of the command is incorrect." sometimes
-    # but not in all cases. What the fuck, cmd.exe.
-    COMPILER: msvc
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    APPVEYOR_JOB_NAME: windows-rt-msvc2017
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   # Same reasoning as in Corrade for /EHsc
+  #   COMPILER_EXTRA: -DCMAKE_CXX_FLAGS="/permissive- /EHsc" -DMSVC_COMPATIBILITY=OFF
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  #   APPVEYOR_JOB_NAME: windows-conforming-msvc2019
+  # - TARGET: desktop
+  #   COMPILER: msvc
+  #   # Not playing with fire and using /EHsc on 2022 as well
+  #   COMPILER_EXTRA: -DCMAKE_CXX_FLAGS="/permissive- /EHsc" -DMSVC_COMPATIBILITY=OFF
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  #   APPVEYOR_JOB_NAME: windows-conforming-msvc2022
+  # - TARGET: desktop
+  #   COMPILER: mingw
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #   APPVEYOR_JOB_NAME: windows-mingw
+  # - TARGET: rt
+  #   # This actually isn't needed anywhere, but without this the %COMPILE:~0,4%
+  #   # expressions cause a "The syntax of the command is incorrect." sometimes
+  #   # but not in all cases. What the fuck, cmd.exe.
+  #   COMPILER: msvc
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #   APPVEYOR_JOB_NAME: windows-rt-msvc2017
 
 install:
 # Ninja. `cinst ninja` started 503ing in late November 2019 and wasn't really

--- a/package/ci/appveyor.yml
+++ b/package/ci/appveyor.yml
@@ -10,10 +10,10 @@ environment:
   #   COMPILER: msvc
   #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
   #   APPVEYOR_JOB_NAME: windows-msvc2017
-  # - TARGET: desktop
-  #   COMPILER: msvc
-  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  #   APPVEYOR_JOB_NAME: windows-msvc2019
+  - TARGET: desktop
+    COMPILER: msvc
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    APPVEYOR_JOB_NAME: windows-msvc2019
   # - TARGET: desktop
   #   COMPILER: msvc
   #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
@@ -91,7 +91,8 @@ install:
 
 # libpng, for MSVC 2022, 2019 and clang-cl. MSVC 2017 seems to work well with
 # the 2019 build, MinGW doesn't work at all due to ABI issues.
-- IF "%TARGET%" == "desktop" IF "%COMPILER:~0,4%" == "msvc" appveyor DownloadFile https://ci.magnum.graphics/libpng-1.6.39-windows-2019.zip && 7z x libpng-1.6.39-windows-2019.zip -o%APPVEYOR_BUILD_FOLDER%\deps
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc" appveyor DownloadFile https://ci.magnum.graphics/libpng-1.6.39-windows-2019.zip && 7z x libpng-1.6.39-windows-2019.zip -o%APPVEYOR_BUILD_FOLDER%\deps
+- IF "%TARGET%" == "desktop" IF "%COMPILER%" == "msvc-clang" appveyor DownloadFile https://ci.magnum.graphics/libpng-1.6.39-windows-2019-clang-cl.zip && 7z x libpng-1.6.39-windows-2019-clang-cl.zip -o%APPVEYOR_BUILD_FOLDER%\deps
 
 # OpenAL
 - IF NOT "%TARGET%" == "rt" IF NOT EXIST %APPVEYOR_BUILD_FOLDER%\openal-soft-1.19.1-bin.zip appveyor DownloadFile https://openal-soft.org/openal-binaries/openal-soft-1.19.1-bin.zip

--- a/src/MagnumPlugins/PngImageConverter/PngImageConverter.cpp
+++ b/src/MagnumPlugins/PngImageConverter/PngImageConverter.cpp
@@ -41,6 +41,7 @@
 #include <csetjmp>
 #include <Corrade/Containers/Array.h>
 #include <Corrade/Containers/Optional.h>
+#include <Corrade/Containers/ScopeGuard.h>
 #include <Corrade/Containers/String.h>
 #include <Magnum/ImageView.h>
 #include <Magnum/PixelFormat.h>
@@ -109,31 +110,58 @@ Containers::Optional<Containers::Array<char>> PngImageConverter::doConvertToData
             return {};
     }
 
-    png_structp file = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
-    /** @todo this will assert if the PNG major/minor version doesn't match,
-        with "libpng warning: Application built with libpng-1.7.0 but running
-        with 1.6.38" being printed to stdout, the proper fix is to set error
-        callbacks directly in the png_create_write_struct() call */
-    CORRADE_INTERNAL_ASSERT(file);
-    png_infop info = png_create_info_struct(file);
-    CORRADE_INTERNAL_ASSERT(info);
+    /* Structures for writing the file. To avoid leaks, everything that needs
+       to be destructed when exiting the function has to be defined *before*
+       the setjmp() call below. */
+    struct PngState {
+        png_structp file;
+        png_infop info;
+    } png{};
+    /** @todo a capturing ScopeGuard would be nicer :( */
+    Containers::ScopeGuard pngStateGuard{&png, [](PngState* state) {
+        /* Although undocumented, this function gracefully handles the case
+           when the file/info is null, no need to check that explicitly. */
+        png_destroy_write_struct(&state->file, &state->info);
+    }};
     std::string output;
 
-    /* Error handling routine. Since we're replacing the png_default_error()
-       function, we need to call std::longjmp() ourselves -- otherwise the
-       default error handling with stderr printing kicks in. */
-    if(setjmp(png_jmpbuf(file))) {
-        png_destroy_write_struct(&file, &info);
-        return {};
-    }
-    png_set_error_fn(file, nullptr, [](const png_structp file, const png_const_charp message) {
+    /* Create the write structure. Directly set up also error/warning
+       callbacks because if done here and not in a subsequent
+       png_set_error_fn() call, it'll gracefully handle also libpng version
+       mismatch errors. */
+    png.file = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, [](const png_structp file, const png_const_charp message) {
         Error{} << "Trade::PngImageConverter::convertToData(): error:" << message;
+        /* Since we're replacing the png_default_error() function, we need to
+           call std::longjmp() ourselves -- otherwise the default error
+           handling with stderr printing kicks in. */
         std::longjmp(png_jmpbuf(file), 1);
     }, [](png_structp, const png_const_charp message) {
-        Warning{} << "Trade::PngImageConverter::convertToData(): warning:" << message;
-    });
+        /* If there's a mismatch in the passed PNG_LIBPNG_VER_STRING major or
+           minor version (but not patch version), png_create_read_struct()
+           returns a nullptr. However, such a *fatal* error is treated as a
+           warning by the library, directed to the warning callback:
+             https://github.com/glennrp/libpng/blob/07b8803110da160b158ebfef872627da6c85cbdf/png.c#L219-L240
+           That may cause great confusion ("why image2D() returns a NullOpt if
+           it was just a warning??"), so I'm detecting that and annotating it
+           as an error instead.
 
-    png_set_write_fn(file, &output, [](png_structp file, png_bytep data, png_size_t length){
+           Unfortunately this case is annoyingly hard to test automatically, so
+           the following branch is uncovered. */
+        if(Containers::StringView{message}.hasPrefix("Application built with libpng-"_s))
+            Error{} << "Trade::PngImageConverter::convertToData(): error:" << message;
+        else
+            Warning{} << "Trade::PngImageConverter::convertToData(): warning:" << message;
+    });
+    /* If png_create_write_struct() failed, png.file is a nullptr. Apart from
+       that we may arrive here from the longjmp from the error callback. */
+    if(!png.file || setjmp(png_jmpbuf(png.file)))
+        return {};
+
+    png.info = png_create_info_struct(png.file);
+    CORRADE_INTERNAL_ASSERT(png.info);
+
+    /* Set functions for writing */
+    png_set_write_fn(png.file, &output, [](png_structp file, png_bytep data, png_size_t length){
         auto&& output = *reinterpret_cast<std::string*>(png_get_io_ptr(file));
         std::size_t oldSize = output.size();
         output.resize(output.size() + length);
@@ -141,10 +169,10 @@ Containers::Optional<Containers::Array<char>> PngImageConverter::doConvertToData
     }, [](png_structp){});
 
     /* Write header */
-    png_set_IHDR(file, info, image.size().x(), image.size().y(),
+    png_set_IHDR(png.file, png.info, image.size().x(), image.size().y(),
         bitDepth, colorType, PNG_INTERLACE_NONE,
         PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
-    png_write_info(file, info);
+    png_write_info(png.file, png.info);
 
     /* Get data properties and calculate the initial slice based on subimage
        offset */
@@ -155,20 +183,19 @@ Containers::Optional<Containers::Array<char>> PngImageConverter::doConvertToData
     /* Write rows in reverse order, properly take stride into account */
     if(bitDepth == 8) {
         for(Int y = 0; y != image.size().y(); ++y)
-            png_write_row(file, const_cast<unsigned char*>(data.exceptPrefix((image.size().y() - y - 1)*dataProperties.second.x()).data()));
+            png_write_row(png.file, const_cast<unsigned char*>(data.exceptPrefix((image.size().y() - y - 1)*dataProperties.second.x()).data()));
 
     /* For 16 bit depth we need to swap to big endian */
     } else if(bitDepth == 16) {
         #ifndef CORRADE_TARGET_BIG_ENDIAN
-        png_set_swap(file);
+        png_set_swap(png.file);
         #endif
         for(Int y = 0; y != image.size().y(); ++y) {
-            png_write_row(file, const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(data.exceptPrefix((image.size().y() - y - 1)*dataProperties.second.x()).data())));
+            png_write_row(png.file, const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(data.exceptPrefix((image.size().y() - y - 1)*dataProperties.second.x()).data())));
         }
     }
 
-    png_write_end(file, nullptr);
-    png_destroy_write_struct(&file, &info);
+    png_write_end(png.file, nullptr);
 
     /* Copy the string into the output array (I would kill for having std::string::release()) */
     Containers::Array<char> fileData{NoInit, output.size()};

--- a/src/MagnumPlugins/PngImporter/PngImporter.cpp
+++ b/src/MagnumPlugins/PngImporter/PngImporter.cpp
@@ -102,37 +102,55 @@ Containers::Optional<ImageData2D> PngImporter::doImage2D(UnsignedInt, UnsignedIn
     }};
     Containers::Array<png_bytep> rows;
     Containers::Array<char> data;
+    /* For exiting out of error callbacks via longjmp. Can't use the builtin
+       png_jmpbuf() because the errors can happen inside
+       png_create_read_struct(), thus even before the png.file gets filled, and
+       thus even before we can call setjmp(png_jmpbuf(png.file)). Yet the
+       official documentation says absolutely nothing about handling such case,
+       F.F.S. */
+    std::jmp_buf jmpbuf;
+    /* We may arrive here from the longjmp from the error callback */
+    if(setjmp(jmpbuf))
+        return {};
 
     /* Create the read structure. Directly set up also error/warning
        callbacks because if done here and not in a subsequent
        png_set_error_fn() call, it'll gracefully handle also libpng version
        mismatch errors. */
-    png.file = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, [](const png_structp file, const png_const_charp message) {
+    png.file = png_create_read_struct(PNG_LIBPNG_VER_STRING, &jmpbuf, [](const png_structp file, const png_const_charp message) {
         Error{} << "Trade::PngImporter::image2D(): error:" << message;
         /* Since we're replacing the png_default_error() function, we need to
            call std::longjmp() ourselves -- otherwise the default error
-           handling with stderr printing kicks in. */
-        std::longjmp(png_jmpbuf(file), 1);
-    }, [](png_structp, const png_const_charp message) {
+           handling with stderr printing kicks in. See above for why
+           png_jmpbuf() can't be used. */
+        std::longjmp(*static_cast<std::jmp_buf*>(png_get_error_ptr(file)), 1);
+    }, [](const png_structp file, const png_const_charp message) {
         /* If there's a mismatch in the passed PNG_LIBPNG_VER_STRING major or
            minor version (but not patch version), png_create_read_struct()
            returns a nullptr. However, such a *fatal* error is treated as a
            warning by the library, directed to the warning callback:
              https://github.com/glennrp/libpng/blob/07b8803110da160b158ebfef872627da6c85cbdf/png.c#L219-L240
            That may cause great confusion ("why image2D() returns a NullOpt if
-           it was just a warning??"), so I'm detecting that and annotating it
-           as an error instead.
+           it was just a warning??"), so I'm detecting that, annotating it as
+           an error instead, and jumping to the error return so we don't end up
+           with a nullptr `png.file` below.
 
            Unfortunately this case is annoyingly hard to test automatically, so
            the following branch is uncovered. */
-        if(Containers::StringView{message}.hasPrefix("Application built with libpng-"_s))
+        if(Containers::StringView{message}.hasPrefix("Application built with libpng-"_s)) {
             Error{} << "Trade::PngImporter::image2D(): error:" << message;
-        else
+            std::longjmp(*static_cast<std::jmp_buf*>(png_get_error_ptr(file)), 1);
+        } else
             Warning{} << "Trade::PngImporter::image2D(): warning:" << message;
     });
-    /* If png_create_read_struct() failed, png.file is a nullptr. Apart from
-       that we may arrive here from the longjmp from the error callback. */
-    if(!png.file || setjmp(png_jmpbuf(png.file)))
+    /* If png_create_read_struct() failed with an error or "failed with a
+       warning" due to the version mismatch), in both cases it longjmp()'d and
+       already returned above. So if we get to this point, the file pointer
+       should always be there. */
+    CORRADE_INTERNAL_ASSERT(png.file);
+
+    // FFS
+    if(setjmp(jmpbuf))
         return {};
 
     png.info = png_create_info_struct(png.file);


### PR DESCRIPTION
Before https://github.com/mosra/magnum-plugins/commit/7e55228576437d56b791639d18d976498a714f8e, there was an assert where even patch version jump caused the plugin to abort. Which happens pretty regularly, last with 1.6.38 -> 39, and is nothing that should be treated as a critical failure (I wonder what "libpng tutorial" was that taken from, sigh). The above-referenced commit removed this assert in order to unblock users, however it meant that a hypotetical upgrade from 1.6.x to 1.7 would cause the `png_create_{read,write}_struct()` to print for example

    libpng warning: Application built with libpng-1.7.0 but running with 1.6.39

directly to the stdout (thus, impossible to see on e.g. Android), and then the plugin immediately does on `CORRADE_INTERNAL_ASSERT(png.file)`. This attempts to fix it properly.

The `png_create_{read,write}_struct()` API accepts error/warning callbacks on its own, so supplying them there instead of in `png_set_error_fn()` allows it to direct the version mismatch error to us. Which is how it
should have been done in the first place (and again, I have no idea why the *official* libpng documentation doesn't show that, FFS).

Unfortunately, libpng directs the major/minor version mismatch *fatal error* to the warning callback, which is extremely confusing, and there's no way to detect and fixup the case apart from comparing the
string itself.

So that's what the first commit in this PR does. But then the changes cause a total breakage on clang-cl, and only there, with `longjmp`/`setjmp` causing the program to jump somewhere totally insane, hitting assertions in `Debug` destructor code paths that only ever get hit when `!Debug` is used (which it isn't). Random ideas:

- [ ] https://en.cppreference.com/w/cpp/utility/program/longjmp says the following. The plugin attempts to have everything constructed *before* the first `longjmp` and destructed *after* the last `setjmp`, but maybe not correctly?

    > If replacing of `std::longjmp()` with `throw` and `setjmp()` with `catch` would execute a non-trivial destructor for any automatic object, the behavior of such `std::longjmp` is undefined. 

- [ ] The following patch from @Squareys seems to make the test run again, however we don't yet understand why. I refuse to accept that the assertions, which *may* construct a `Debug` instance on stack, are what's causing problems -- that'd mean having to redesign the whole debug output printing...

```diff
diff --git a/src/MagnumPlugins/PngImporter/PngImporter.cpp b/src/MagnumPlugins/PngImporter/PngImporter.cpp
index a1b4b893..8c6d60c7 100644
--- a/src/MagnumPlugins/PngImporter/PngImporter.cpp
+++ b/src/MagnumPlugins/PngImporter/PngImporter.cpp
@@ -156,6 +156,10 @@ Containers::Optional<ImageData2D> PngImporter::doImage2D(UnsignedInt, UnsignedIn
     png.info = png_create_info_struct(png.file);
     CORRADE_INTERNAL_ASSERT(png.info);
 
+    // FFS
+    if (setjmp(jmpbuf))
+        return {};
+
     /* Set functions for reading */
     Containers::ArrayView<char> input = _in;
     png_set_read_fn(png.file, &input, [](const png_structp file, const png_bytep data, const png_size_t length) {
@@ -181,6 +185,8 @@ Containers::Optional<ImageData2D> PngImporter::doImage2D(UnsignedInt, UnsignedIn
         /* Types that can be used without conversion */
         case PNG_COLOR_TYPE_GRAY:
             CORRADE_INTERNAL_ASSERT(channels == 1);
+            if (setjmp(jmpbuf))
+                return {};
 
             /* Convert to 8-bit */
             if(bits < 8) {
@@ -221,6 +227,9 @@ Containers::Optional<ImageData2D> PngImporter::doImage2D(UnsignedInt, UnsignedIn
         /* LCOV_EXCL_STOP */
     }
 
+    if (setjmp(jmpbuf))
+        return {};
+
     /* Convert transparency mask to alpha */
     if(png_get_valid(png.file, png.info, PNG_INFO_tRNS)) {
         png_set_tRNS_to_alpha(png.file);
@@ -245,6 +254,8 @@ Containers::Optional<ImageData2D> PngImporter::doImage2D(UnsignedInt, UnsignedIn
 
     /* Initialize data array, align rows to four bytes */
     CORRADE_INTERNAL_ASSERT(bits >= 8);
+    if (setjmp(jmpbuf))
+        return {};
     const std::size_t stride = ((size.x()*channels*bits/8 + 3)/4)*4;
     data = Containers::Array<char>{stride*std::size_t(size.y())};
```

- [ ] This all worked well before, which means there has to be something wrong in the patch? Is there a middle-ground version of it that behaves like before, but is also able to catch the initial version mismatch error message so it doesn't go to stdout?
- [ ] libpng calls `setjmp()` on its own [inside the create function](https://github.com/glennrp/libpng/blob/07b8803110da160b158ebfef872627da6c85cbdf/png.c#L302) (to catch the version error and return `nullptr`), could this be the sole reason for everything catching fire? why is that a problem just for clang-cl?
- [x] It's not an issue specific to clang-cl 15+, it happens also on clang-cl 12. It was just that libpng got installed via vcpkg before, and vcpkg is a broken crap so it got gradually disabled for most of the CI jobs. This is fixed as of 1366ec591a4053def15cca4200bc2490b582b431.
- [x] It doesn't seem to be an issue related to some minor ABI issue between MSVC and clang-cl. It happens even with libpng compiled with clang-cl.
- [x] There doesn't seem to be any known Windows-specific clang bug related to `longjmp`. The only vaguely relevant bugs are:
 - https://github.com/llvm/llvm-project/issues/51055
 - https://github.com/llvm/llvm-project/issues/49486