### PR TITLE
Add PBR properties

### DIFF
--- a/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
+++ b/src/MagnumPlugins/AssimpImporter/AssimpImporter.cpp
@@ -1628,6 +1628,15 @@ Containers::Optional<MaterialData> AssimpImporter::doMaterial(const UnsignedInt 
                             case aiTextureType_NORMALS:
                                 attribute = MaterialAttribute::NormalTextureMatrix;
                                 break;
+                            case aiTextureType_METALNESS:
+                                attribute = MaterialAttribute::MetalnessTextureMatrix;
+                                break;
+                            case aiTextureType_BASE_COLOR:
+                                attribute = MaterialAttribute::BaseColorTextureMatrix;
+                                break;
+                            case aiTextureType_DIFFUSE_ROUGHNESS:
+                                attribute = MaterialAttribute::RoughnessTextureMatrix;
+                                break;
                         }
 
                         /* Save only if the name is recognized (and let it
@@ -1668,7 +1677,23 @@ Containers::Optional<MaterialData> AssimpImporter::doMaterial(const UnsignedInt 
                             case aiTextureType_NORMALS:
                                 attribute = MaterialAttribute::NormalTextureCoordinates;
                                 break;
+                            case aiTextureType_METALNESS:
+                                attribute = MaterialAttribute::MetalnessTextureCoordinates;
+                                break;
+                            case aiTextureType_BASE_COLOR:
+                                attribute = MaterialAttribute::BaseColorTextureCoordinates;
+                                break;
+                            case aiTextureType_DIFFUSE_ROUGHNESS:
+                                attribute = MaterialAttribute::RoughnessTextureCoordinates;
+                                break;
                         }
+                    } else if(property.mType == aiPTI_Integer) {
+                        if(key == AI_MATKEY_USE_COLOR_MAP && property.mSemantic == aiTextureType_BASE_COLOR)
+                            attribute = MaterialAttribute::BaseColorTexture;
+                        if(key == AI_MATKEY_USE_METALLIC_MAP && property.mSemantic == aiTextureType_METALNESS)
+                            attribute = MaterialAttribute::MetalnessTexture;
+                        if(key == AI_MATKEY_USE_ROUGHNESS_MAP && property.mSemantic == aiTextureType_DIFFUSE_ROUGHNESS)
+                            attribute = MaterialAttribute::RoughnessTexture;
                     }
                 }
 


### PR DESCRIPTION
Hi @mosra, @Squareys,
This is my first commit on the task of integrating PBR materials. 

I have trouble understanding/discerning the boundaries of textures and materials, especially in the code. I added PBR properties in texture related properties but I am not sure if my approach is relevant at all for the solution of the task. Besides, I am quite confused about the definitions in assimp/material.h and not sure if I used these definitions correctly as property keys in AssimpImporter. An clarification would be great.

Another question I want to ask is the usage of the function _str(). I wonder why it is used in only some of the equality comparisons of property keys, e.g:

`key == _str(AI_MATKEY_SHININESS)`      vs.     
`key == _AI_MATKEY_TEXTURE_BASE`