### PR TITLE
BasisImporter: add formatHdr config option

### DIFF
--- a/doc/snippets/BasisImporter.cpp
+++ b/doc/snippets/BasisImporter.cpp
@@ -92,7 +92,9 @@ if(PluginManager::PluginMetadata* metadata = manager.metadata("BasisImporter")) 
     GL::Context& context = GL::Context::current();
     using namespace GL::Extensions;
     #ifdef MAGNUM_TARGET_WEBGL
-    if(context.isExtensionSupported<WEBGL::compressed_texture_astc>())
+    /* Pseudo-extension that checks for WEBGL_compressed_texture_astc plus the
+       presence of the LDR profile */
+    if(context.isExtensionSupported<MAGNUM::compressed_texture_astc_ldr>())
     #else
     if(context.isExtensionSupported<KHR::texture_compression_astc_ldr>())
     #endif
@@ -150,6 +152,38 @@ if(PluginManager::PluginMetadata* metadata = manager.metadata("BasisImporter")) 
     #endif
 }
 /* [gl-extension-checks] */
+
+/* [gl-extension-checks-hdr] */
+if(PluginManager::PluginMetadata* metadata = manager.metadata("BasisImporter")) {
+    GL::Context& context = GL::Context::current();
+    using namespace GL::Extensions;
+    #ifdef MAGNUM_TARGET_WEBGL
+    /* Pseudo-extension that checks for WEBGL_compressed_texture_astc plus the
+       presence of the HDR profile */
+    if(context.isExtensionSupported<MAGNUM::compressed_texture_astc_hdr>())
+    #else
+    if(context.isExtensionSupported<KHR::texture_compression_astc_hdr>())
+    #endif
+    {
+        metadata->configuration().setValue("formatHdr", "Astc4x4RGBAF");
+    }
+    /* BC6 extension is available on WebGL 1 and 2, but not ES2 */
+    #if !defined(MAGNUM_TARGET_GLES2) || defined(MAGNUM_TARGET_WEBGL)
+    #ifdef MAGNUM_TARGET_GLES
+    else if(context.isExtensionSupported<EXT::texture_compression_bptc>())
+    #else
+    else if(context.isExtensionSupported<ARB::texture_compression_bptc>())
+    #endif
+    {
+        metadata->configuration().setValue("formatHdr", "Bc6hRGB");
+    }
+    #endif
+    else {
+        /* Fall back to uncompressed if nothing else is supported */
+        metadata->configuration().setValue("formatHdr", "RGBA16F");
+    }
+}
+/* [gl-extension-checks-hdr] */
 }
 #endif
 

--- a/doc/snippets/BasisImporter.cpp
+++ b/doc/snippets/BasisImporter.cpp
@@ -44,13 +44,19 @@ int main() {
 {
 PluginManager::Manager<Trade::AbstractImporter> manager;
 /* [target-format-suffix] */
-/* Choose ETC2 target format */
+/* Choose ETC2 target format. Sets the format configuration option and leaves
+   formatHdr at its default. */
 Containers::Pointer<Trade::AbstractImporter> importerEtc2 =
     manager.instantiate("BasisImporterEtc2RGBA");
 
 /* Choose BC5 target format */
 Containers::Pointer<Trade::AbstractImporter> importerBc5 =
     manager.instantiate("BasisImporterBc5RG");
+
+/* Choose BC6 target format. This is an HDR format, so sets the formatHdr
+   configuration option and leaves format at its default. */
+Containers::Pointer<Trade::AbstractImporter> importerBc6 =
+    manager.instantiate("BasisImporterBc6hRGB");
 /* [target-format-suffix] */
 }
 
@@ -59,18 +65,20 @@ PluginManager::Manager<Trade::AbstractImporter> manager;
 Containers::Optional<Trade::ImageData2D> image;
 /* [target-format-config] */
 /* Instantiate the plugin under its default name. At this point, the plugin
-   would decompress to full RGBA8, which is usually not what you want. */
+   would decompress to full RGBA8/RGBA16F, which is usually not what you want. */
 Containers::Pointer<Trade::AbstractImporter> importer =
     manager.instantiate("BasisImporter");
 importer->openFile("mytexture.basis");
 
-/* Transcode the image to BC5 */
+/* Transcode LDR images to BC5, and HDR images to ASTC4x4F */
 importer->configuration().setValue("format", "Bc5RG");
+importer->configuration().setValue("formatHdr", "Astc4x4RGBAF");
 image = importer->image2D(0);
 // ...
 
-/* Transcode the same image, but to ETC2 now */
+/* Transcode the same image, but to ETC2/BC6 now */
 importer->configuration().setValue("format", "Etc2RGBA");
+importer->configuration().setValue("formatHdr", "Bc6hRGB");
 image = importer->image2D(0);
 // ...
 /* [target-format-config] */

--- a/doc/snippets/BasisImporter.cpp
+++ b/doc/snippets/BasisImporter.cpp
@@ -46,11 +46,11 @@ PluginManager::Manager<Trade::AbstractImporter> manager;
 /* [target-format-suffix] */
 /* Choose ETC2 target format */
 Containers::Pointer<Trade::AbstractImporter> importerEtc2 =
-    manager.instantiate("BasisImporterEtc2");
+    manager.instantiate("BasisImporterEtc2RGBA");
 
 /* Choose BC5 target format */
 Containers::Pointer<Trade::AbstractImporter> importerBc5 =
-    manager.instantiate("BasisImporterBc5");
+    manager.instantiate("BasisImporterBc5RG");
 /* [target-format-suffix] */
 }
 
@@ -65,12 +65,12 @@ Containers::Pointer<Trade::AbstractImporter> importer =
 importer->openFile("mytexture.basis");
 
 /* Transcode the image to BC5 */
-importer->configuration().setValue("format", "Bc5");
+importer->configuration().setValue("format", "Bc5RG");
 image = importer->image2D(0);
 // ...
 
 /* Transcode the same image, but to ETC2 now */
-importer->configuration().setValue("format", "Etc2");
+importer->configuration().setValue("format", "Etc2RGBA");
 image = importer->image2D(0);
 // ...
 /* [target-format-config] */

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.conf
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.conf
@@ -28,8 +28,11 @@ assumeYUp=
 
 # No format is specified by default and you have to choose one either by
 # changing this value or by loading the plugin under an alias. Should be one
-# of Etc1RGB, Etc2RGBA, EacR, EacRG, Bc1RGB, Bc3RGBA, Bc4R, Bc5RG, Bc6hRGB,
-# Bc7RGBA, PvrtcRGB4bpp, PvrtcRGBA4bpp, Astc4x4RGBA, Astc4x4RGBAF, RGBA8,
-# RGB16F or RGBA16F. If not set, falls back to RGBA8 or RGBA16F with a warning.
+# of Etc1RGB, Etc2RGBA, EacR, EacRG, Bc1RGB, Bc3RGBA, Bc4R, Bc5RG, Bc7RGBA,
+# PvrtcRGB4bpp, PvrtcRGBA4bpp or RGBA8. If not set, falls back to RGBA8 with a
+# warning. Not used for transcoding HDR images, set formatHdr for those.
 format=
+# Same as format, but for HDR images. Should be one of Bc6hRGB, Astc4x4RGBAF,
+# RGB16F or RGBA16F. If not set, falls back to RGBA16F with a warning.
+formatHdr=
 # [configuration_]

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.h
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.h
@@ -61,9 +61,11 @@ namespace Magnum { namespace Trade {
 
 @m_keywords{BasisImporterEacR BasisImporterEacRG BasisImporterEtc1RGB}
 @m_keywords{BasisImporterEtc2RGBA BasisImporterBc1RGB BasisImporterBc3RGBA}
-@m_keywords{BasisImporterBc4R BasisImporterBc5RG BasisImporterBc7RGBA}
-@m_keywords{BasisImporterPvrtc1RGB4bpp BasisImporterPvrtc1RGBA4bpp}
-@m_keywords{BasisImporterAstc4x4RGBA BasisImporterRGBA8}
+@m_keywords{BasisImporterBc4R BasisImporterBc5RG BasisImporterBc6hRGB}
+@m_keywords{BasisImporterBc7RGBA BasisImporterPvrtc1RGB4bpp}
+@m_keywords{BasisImporterPvrtc1RGBA4bpp BasisImporterAstc4x4RGBA}
+@m_keywords{BasisImporterAstc4x4RGBAF BasisImporterRGBA8 BasisImporterRGB16F}
+@m_keywords{BasisImporterRGBA16F}
 
 Imports [Basis Universal](https://github.com/binomialLLC/basis_universal)
 compressed images (`*.basis` or `*.ktx2`) by parsing and transcoding files into

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.h
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.h
@@ -245,19 +245,17 @@ to edit the configuration values.
 @subsection Trade-BasisImporter-target-format Target format
 
 Basis is a compressed format that is *transcoded* into a compressed GPU format.
-With @ref BasisImporter, this format can be chosen in different ways:
+When loading an HDR image, it will be transcoded to an HDR target format.
+Conversely, non-HDR images can only be transcoded to non-HDR formats.
+With @ref BasisImporter, these formats can be chosen in different ways:
 
 @snippet BasisImporter.cpp target-format-suffix
 
 The list of valid suffixes is equivalent to enum value names in
 @ref TargetFormat. If you want to be able to change the target format
-dynamically, set the @cb{.ini} format @ce @ref Trade-BasisImporter-configuration "configuration option".
+dynamically, set the @cb{.ini} format @ce and @cb{.ini} formatHdr @ce @ref Trade-BasisImporter-configuration "configuration options".
 
 @snippet BasisImporter.cpp target-format-config
-
-HDR images can only be transcoded to one of the HDR formats (`Bc6hRGB` /
-`Astc4x4RGBAF` / `RGB16F` / `RGBA16F`). Likewise, LDR images can only be
-transcoded to non-HDR formats.
 
 There are many options and you should generally be striving for the
 highest-quality format available on a given platform. A detailed description of
@@ -293,8 +291,8 @@ class MAGNUM_BASISIMPORTER_EXPORT BasisImporter: public AbstractImporter {
          *
          * Exposed for documentation purposes only. Pick the format either by
          * loading the plugin under one of the above-listed aliases with the
-         * values as suffix, or by setting the @cb{.ini} format @ce
-         * @ref Trade-BasisImporter-configuration "configuration option".
+         * values as suffix, or by setting the @cb{.ini} format @ce and
+         * @cb{.ini} formatHdr @ce @ref Trade-BasisImporter-configuration "configuration options".
          *
          * If the image does not contain an alpha channel and the target format
          * has it, alpha will be set to opaque. Conversely, for output formats

--- a/src/MagnumPlugins/BasisImporter/BasisImporter.h
+++ b/src/MagnumPlugins/BasisImporter/BasisImporter.h
@@ -266,6 +266,10 @@ OpenGL, OpenGL ES and WebGL extensions, in its full ugly glory:
 
 @snippet BasisImporter.cpp gl-extension-checks
 
+Selecting an HDR format is a bit simpler:
+
+@snippet BasisImporter.cpp gl-extension-checks-hdr
+
 @subsection Trade-BasisImporter-binary-size Reducing binary size
 
 To reduce the binary size of the transcoder, Basis Universal supports a set of

--- a/src/MagnumPlugins/BasisImporter/Test/BasisImporterTest.cpp
+++ b/src/MagnumPlugins/BasisImporter/Test/BasisImporterTest.cpp
@@ -1194,9 +1194,7 @@ void BasisImporterTest::rgb() {
     setTestCaseDescription(formatData.suffix);
 
     #if BASISD_LIB_VERSION < 150
-    /* Iff there is no linear version, this is an HDR format */
-    const bool isHdr = formatData.fileBaseLinear == nullptr;
-    if(isHdr)
+    if(isCompressedPixelFormatFloatingPoint(formatData.expectedFormat))
         CORRADE_SKIP("Current version of Basis doesn't support HDR.");
     #endif
 


### PR DESCRIPTION
As discussed on Gitter. Allows opening Basis images without having to successfully guess whether it's an HDR image or not. Now you can set both and it will get transcoded successfully, without an error about mismatching LDR <-> HDR format.

I thought about splitting the HDR formats out of `TargetFormat` into their own `TargetHdrFormat` enum for easier validation and better documentation, but shied away from it because of backwards compatibility. Might be worth doing though, seeing how the HDR formats only got added very recently.

Still missing some updated docs, but code + tests should be ready for a review 😌

### Todo
- [x] Update docs to mention `formatHdr` and `setTargetFormatHdr()`
- [x] Update target format selection code